### PR TITLE
Fix tests using httpx 0.28

### DIFF
--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,8 +1,8 @@
-from fastapi.testclient import TestClient
+from tests.utils import SyncClient
 
 from app.main import app
 
-client = TestClient(app)
+client = SyncClient(app)
 
 def test_ping():
     response = client.get("/ping")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,8 +1,8 @@
-from fastapi.testclient import TestClient
+from tests.utils import SyncClient
 
 from app.main import app
 
-client = TestClient(app)
+client = SyncClient(app)
 
 def test_create_user():
     response = client.post("/users/", json={"name": "Alice", "target_ielts": 7, "target_hsk": 180})

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,25 @@
+import anyio
+import httpx
+from fastapi import FastAPI
+
+
+class SyncClient:
+    """Minimal synchronous client for FastAPI apps using httpx.ASGITransport."""
+
+    def __init__(self, app: FastAPI):
+        self.app = app
+        self.transport = httpx.ASGITransport(app=app)
+        self.base_url = "http://testserver"
+
+    def request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        async def _call() -> httpx.Response:
+            async with httpx.AsyncClient(transport=self.transport, base_url=self.base_url) as client:
+                return await client.request(method, url, **kwargs)
+
+        return anyio.run(_call)
+
+    def get(self, url: str, **kwargs) -> httpx.Response:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs) -> httpx.Response:
+        return self.request("POST", url, **kwargs)


### PR DESCRIPTION
## Summary
- create a minimal synchronous `SyncClient` for testing
- update tests to use the new helper
- add `tests/__init__.py` to make `tests` a package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a96ad6e08320b0be2b41134c3f21