### PR TITLE
Add exam engine and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ This repository contains a small [FastAPI](https://fastapi.tiangolo.com/) applic
    ```
    The API will be available at [http://127.0.0.1:8000](http://127.0.0.1:8000). The `/ping` endpoint returns a simple health check.
 
+  The root URL serves a React single-page application with pages for a
+  dashboard, exams, and practice drills. Static assets live under `/static`
+  and require the server to be running.
+
+   Additional endpoints:
+   - `POST /users/` – create a user.
+   - `GET /users/` – list all users.
+   - `GET /users/{user_id}` – retrieve a user by ID.
+   - `GET /exams/IELTS` – fetch the sample IELTS exam with questions.
+   - `POST /exams/IELTS/submit` – submit answers and record an attempt.
+   - `GET /dashboard/{user_id}` – show skill profile and exam-ready status.
+
 3. **Run tests** *(optional)*
    ```bash
    pytest -q

--- a/app/crud.py
+++ b/app/crud.py
@@ -9,3 +9,88 @@ def create_user(db: Session, user: schemas.UserCreate) -> models.User:
     db.commit()
     db.refresh(db_user)
     return db_user
+
+
+def get_user(db: Session, user_id: int) -> models.User | None:
+    """Return a user by ID or None if not found."""
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def list_users(db: Session) -> list[models.User]:
+    """Return all users."""
+    return db.query(models.User).all()
+
+
+def get_test(db: Session, exam_type: str) -> models.Test | None:
+    return db.query(models.Test).filter(models.Test.exam_type == exam_type).first()
+
+
+def record_attempt(
+    db: Session, user_id: int, test: models.Test, answers: list[schemas.AnswerCreate]
+) -> models.Attempt:
+    correct = 0
+    attempt = models.Attempt(user_id=user_id, test_id=test.id)
+    db.add(attempt)
+    db.commit()
+    db.refresh(attempt)
+    for ans in answers:
+        q = db.query(models.Question).get(ans.question_id)
+        is_correct = q and q.answer_key == ans.response
+        db.add(
+            models.Answer(
+                attempt_id=attempt.id,
+                question_id=ans.question_id,
+                response=ans.response,
+                correct=is_correct,
+            )
+        )
+        if is_correct:
+            correct += 1
+    total = len(answers) or 1
+    attempt.score = correct / total * 100
+    db.commit()
+    update_skill_profile(db, user_id, "reading", attempt.score)
+    db.refresh(attempt)
+    return attempt
+
+
+def update_skill_profile(db: Session, user_id: int, skill: str, score: float) -> None:
+    profile = (
+        db.query(models.SkillProfile)
+        .filter(models.SkillProfile.user_id == user_id, models.SkillProfile.skill_code == skill)
+        .first()
+    )
+    if not profile:
+        profile = models.SkillProfile(user_id=user_id, skill_code=skill, mastery_pct=score)
+        db.add(profile)
+    else:
+        profile.mastery_pct = (profile.mastery_pct + score) / 2
+    db.commit()
+
+
+def latest_attempts(db: Session, user_id: int, exam_type: str, limit: int = 2) -> list[models.Attempt]:
+    return (
+        db.query(models.Attempt)
+        .join(models.Test)
+        .filter(models.Attempt.user_id == user_id, models.Test.exam_type == exam_type)
+        .order_by(models.Attempt.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def exam_ready(db: Session, user: models.User, exam_type: str) -> bool:
+    attempts = latest_attempts(db, user.id, exam_type, 2)
+    if len(attempts) < 2:
+        return False
+    scores = [a.score for a in attempts]
+    mean = sum(scores) / 2
+    variance = sum((s - mean) ** 2 for s in scores) / 2
+    std = variance ** 0.5
+    if exam_type == "IELTS":
+        target = user.target_ielts * 10  # treat as 7.0 -> 70
+        threshold = 0.25 * 10
+    else:
+        target = user.target_hsk
+        threshold = 15
+    return min(scores) >= target and std < threshold

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import NoResultFound
 
 from .database import engine, Base, SessionLocal
 from . import models, schemas, crud
@@ -7,6 +10,47 @@ from . import models, schemas, crud
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="SoloLingua Coach API")
+
+# Serve the frontend built with plain HTML/JS
+app.mount("/static", StaticFiles(directory="frontend"), name="static")
+
+
+def seed_content(db: Session) -> None:
+    """Create a simple IELTS reading test with two questions if empty."""
+    if db.query(models.Test).first():
+        return
+    test = models.Test(exam_type="IELTS", level=1, section="Reading", title="Sample Reading")
+    db.add(test)
+    db.commit()
+    db.refresh(test)
+    questions = [
+        models.Question(
+            test_id=test.id,
+            prompt="What is 2 + 2?",
+            options_json="[\"3\", \"4\", \"5\"]",
+            answer_key="4",
+            skill_code="reading",
+        ),
+        models.Question(
+            test_id=test.id,
+            prompt="Capital of France?",
+            options_json="[\"London\", \"Paris\", \"Berlin\"]",
+            answer_key="Paris",
+            skill_code="reading",
+        ),
+    ]
+    db.add_all(questions)
+    db.commit()
+
+
+with SessionLocal() as db:
+    seed_content(db)
+
+
+@app.get("/", include_in_schema=False)
+def root() -> FileResponse:
+    """Return the main frontend page."""
+    return FileResponse("frontend/index.html")
 
 
 def get_db():
@@ -25,3 +69,52 @@ def ping():
 @app.post("/users/", response_model=schemas.User)
 def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
     return crud.create_user(db, user)
+
+
+@app.get("/users/", response_model=list[schemas.User])
+def read_users(db: Session = Depends(get_db)):
+    return crud.list_users(db)
+
+
+@app.get("/users/{user_id}", response_model=schemas.User)
+def read_user(user_id: int, db: Session = Depends(get_db)):
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.get("/exams/{exam_type}", response_model=schemas.Test)
+def get_exam(exam_type: str, db: Session = Depends(get_db)):
+    test = crud.get_test(db, exam_type)
+    if not test:
+        raise HTTPException(status_code=404, detail="Test not found")
+    return test
+
+
+@app.post("/exams/{exam_type}/submit", response_model=schemas.Attempt)
+def submit_exam(exam_type: str, submission: schemas.ExamSubmission, db: Session = Depends(get_db)):
+    user = crud.get_user(db, submission.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    test = crud.get_test(db, exam_type)
+    if not test:
+        raise HTTPException(status_code=404, detail="Test not found")
+    attempt = crud.record_attempt(db, submission.user_id, test, submission.answers)
+    return attempt
+
+
+@app.get("/dashboard/{user_id}")
+def dashboard(user_id: int, db: Session = Depends(get_db)):
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    ready = {
+        "ielts": crud.exam_ready(db, user, "IELTS"),
+        "hsk": crud.exam_ready(db, user, "HSK"),
+    }
+    profile = db.query(models.SkillProfile).filter(models.SkillProfile.user_id == user_id).all()
+    return {
+        "exam_ready": ready,
+        "skill_profile": [{"skill": p.skill_code, "pct": p.mastery_pct} for p in profile],
+    }

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
 
 from .database import Base
 
@@ -9,3 +11,58 @@ class User(Base):
     name = Column(String, index=True)
     target_ielts = Column(Integer)
     target_hsk = Column(Integer)
+
+
+class Test(Base):
+    __tablename__ = "tests"
+
+    id = Column(Integer, primary_key=True, index=True)
+    exam_type = Column(String, index=True)
+    level = Column(Integer)
+    section = Column(String)
+    title = Column(String)
+    questions = relationship("Question", back_populates="test")
+
+
+class Question(Base):
+    __tablename__ = "questions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    test_id = Column(Integer, ForeignKey("tests.id"))
+    prompt = Column(String)
+    options_json = Column(String)
+    answer_key = Column(String)
+    skill_code = Column(String)
+    test = relationship("Test", back_populates="questions")
+
+
+class Attempt(Base):
+    __tablename__ = "attempts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    test_id = Column(Integer, ForeignKey("tests.id"))
+    score = Column(Float)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    answers = relationship("Answer", back_populates="attempt")
+
+
+class Answer(Base):
+    __tablename__ = "answers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    attempt_id = Column(Integer, ForeignKey("attempts.id"))
+    question_id = Column(Integer, ForeignKey("questions.id"))
+    response = Column(String)
+    correct = Column(Boolean)
+    attempt = relationship("Attempt", back_populates="answers")
+
+
+class SkillProfile(Base):
+    __tablename__ = "skill_profile"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    skill_code = Column(String, index=True)
+    mastery_pct = Column(Float, default=0.0)
+    last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -10,3 +10,45 @@ class User(UserCreate):
 
     class Config:
         orm_mode = True
+
+
+class Question(BaseModel):
+    id: int
+    prompt: str
+    options_json: str
+    answer_key: str
+    skill_code: str
+
+    class Config:
+        orm_mode = True
+
+
+class Test(BaseModel):
+    id: int
+    exam_type: str
+    level: int
+    section: str
+    title: str
+    questions: list[Question]
+
+    class Config:
+        orm_mode = True
+
+
+class AnswerCreate(BaseModel):
+    question_id: int
+    response: str
+
+
+class Attempt(BaseModel):
+    id: int
+    test_id: int
+    score: float
+
+    class Config:
+        orm_mode = True
+
+
+class ExamSubmission(BaseModel):
+    user_id: int
+    answers: list[AnswerCreate]

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -1,0 +1,100 @@
+const { HashRouter, Route, Switch, Link } = ReactRouterDOM;
+
+function Dashboard() {
+  const [data, setData] = React.useState(null);
+  React.useEffect(() => {
+    fetch('/dashboard/1')
+      .then(res => res.json())
+      .then(setData);
+  }, []);
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      {data ? (
+        <div>
+          <pre>{JSON.stringify(data, null, 2)}</pre>
+        </div>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+}
+
+function Exams() {
+  const [test, setTest] = React.useState(null);
+  const [answers, setAnswers] = React.useState({});
+  const [score, setScore] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch('/exams/IELTS')
+      .then(res => res.json())
+      .then(setTest);
+  }, []);
+
+  const handleSubmit = () => {
+    const payload = {
+      user_id: 1,
+      answers: Object.entries(answers).map(([question_id, response]) => ({ question_id: parseInt(question_id), response }))
+    };
+    fetch('/exams/IELTS/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(res => res.json()).then(data => setScore(data.score));
+  };
+
+  if (!test) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>{test.title}</h2>
+      {test.questions.map(q => (
+        <div key={q.id}>
+          <p>{q.prompt}</p>
+          {JSON.parse(q.options_json).map(opt => (
+            <label key={opt}>
+              <input
+                type="radio"
+                name={q.id}
+                value={opt}
+                onChange={e => setAnswers({ ...answers, [q.id]: e.target.value })}
+              />
+              {opt}
+            </label>
+          ))}
+        </div>
+      ))}
+      <button onClick={handleSubmit}>Submit</button>
+      {score !== null && <p>Score: {score}</p>}
+    </div>
+  );
+}
+
+function PracticeDrills() {
+  return (
+    <div>
+      <h2>Practice Drills</h2>
+      <p>Drill activities will be available here.</p>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <HashRouter>
+      <nav>
+        <Link to="/">Dashboard</Link>{' | '}
+        <Link to="/exams">Exams</Link>{' | '}
+        <Link to="/practice">Practice</Link>
+      </nav>
+      <Switch>
+        <Route exact path="/" component={Dashboard} />
+        <Route path="/exams" component={Exams} />
+        <Route path="/practice" component={PracticeDrills} />
+      </Switch>
+    </HashRouter>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SoloLingua Coach</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; }
+        nav a { margin-right: 1rem; }
+    </style>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@5/umd/react-router-dom.min.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+    <h1>SoloLingua Coach</h1>
+    <div id="root"></div>
+    <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/tests/test_exam.py
+++ b/tests/test_exam.py
@@ -1,0 +1,24 @@
+from tests.utils import SyncClient
+from app.main import app
+
+client = SyncClient(app)
+
+
+def test_get_exam():
+    resp = client.get('/exams/IELTS')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['exam_type'] == 'IELTS'
+    assert len(data['questions']) >= 1
+
+
+def test_submit_exam_and_dashboard_ready():
+    exam = client.get('/exams/IELTS').json()
+    answers = [{'question_id': q['id'], 'response': q['answer_key']} for q in exam['questions']]
+    client.post('/users/', json={'name': 'Test', 'target_ielts': 7, 'target_hsk': 180})
+    # submit two perfect attempts
+    for _ in range(2):
+        resp = client.post('/exams/IELTS/submit', json={'user_id': 1, 'answers': answers})
+        assert resp.status_code == 200
+    dash = client.get('/dashboard/1').json()
+    assert dash['exam_ready']['ielts'] is True

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,10 @@
+from tests.utils import SyncClient
+
+from app.main import app
+
+client = SyncClient(app)
+
+def test_root_serves_frontend():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "SoloLingua Coach" in response.text

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -12,3 +12,28 @@ def test_create_user():
     assert data["target_ielts"] == 7
     assert data["target_hsk"] == 180
     assert "id" in data
+
+
+def test_get_user():
+    response = client.post(
+        "/users/",
+        json={"name": "Bob", "target_ielts": 6, "target_hsk": 170},
+    )
+    user = response.json()
+    user_id = user["id"]
+
+    resp = client.get(f"/users/{user_id}")
+    assert resp.status_code == 200
+    assert resp.json() == user
+
+
+def test_list_users():
+    client.post(
+        "/users/",
+        json={"name": "Eve", "target_ielts": 6, "target_hsk": 160},
+    )
+    resp = client.get("/users/")
+    assert resp.status_code == 200
+    users = resp.json()
+    assert isinstance(users, list)
+    assert len(users) >= 1


### PR DESCRIPTION
## Summary
- seed a simple IELTS reading exam on startup
- add models for tests, questions, attempts, answers, and skill profiles
- implement scoring, skill updates, and exam-ready gating
- expose `/exams`, `/dashboard`, and exam submission endpoints
- display dashboard and exam UI in the React SPA
- test exam submission and gating logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ad29666883209117dc56d2b28604