### PR TITLE
Implement reading/listening engine with auto‑scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This repository contains a small [FastAPI](https://fastapi.tiangolo.com/) applic
    - `POST /users/` – create a user.
    - `GET /users/` – list all users.
    - `GET /users/{user_id}` – retrieve a user by ID.
-   - `GET /exams/IELTS` – fetch the sample IELTS exam with questions.
-   - `POST /exams/IELTS/submit` – submit answers and record an attempt.
+   - `GET /exams/IELTS/{section}` – fetch a sample IELTS section (`Reading` or `Listening`).
+   - `POST /exams/IELTS/{section}/submit` – submit answers for that section.
    - `GET /dashboard/{user_id}` – show skill profile and exam-ready status.
 
 3. **Run tests** *(optional)*

--- a/app/crud.py
+++ b/app/crud.py
@@ -21,8 +21,12 @@ def list_users(db: Session) -> list[models.User]:
     return db.query(models.User).all()
 
 
-def get_test(db: Session, exam_type: str) -> models.Test | None:
-    return db.query(models.Test).filter(models.Test.exam_type == exam_type).first()
+def get_test(db: Session, exam_type: str, section: str) -> models.Test | None:
+    return (
+        db.query(models.Test)
+        .filter(models.Test.exam_type == exam_type, models.Test.section == section)
+        .first()
+    )
 
 
 def record_attempt(
@@ -49,7 +53,7 @@ def record_attempt(
     total = len(answers) or 1
     attempt.score = correct / total * 100
     db.commit()
-    update_skill_profile(db, user_id, "reading", attempt.score)
+    update_skill_profile(db, user_id, test.section.lower(), attempt.score)
     db.refresh(attempt)
     return attempt
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,30 +16,66 @@ app.mount("/static", StaticFiles(directory="frontend"), name="static")
 
 
 def seed_content(db: Session) -> None:
-    """Create a simple IELTS reading test with two questions if empty."""
+    """Create sample IELTS reading and listening tests if none exist."""
     if db.query(models.Test).first():
         return
-    test = models.Test(exam_type="IELTS", level=1, section="Reading", title="Sample Reading")
-    db.add(test)
+
+    reading = models.Test(
+        exam_type="IELTS",
+        level=1,
+        section="Reading",
+        title="Sample Reading",
+    )
+    db.add(reading)
     db.commit()
-    db.refresh(test)
-    questions = [
+    db.refresh(reading)
+    reading_questions = [
         models.Question(
-            test_id=test.id,
+            test_id=reading.id,
             prompt="What is 2 + 2?",
             options_json="[\"3\", \"4\", \"5\"]",
             answer_key="4",
             skill_code="reading",
         ),
         models.Question(
-            test_id=test.id,
+            test_id=reading.id,
             prompt="Capital of France?",
             options_json="[\"London\", \"Paris\", \"Berlin\"]",
             answer_key="Paris",
             skill_code="reading",
         ),
     ]
-    db.add_all(questions)
+    db.add_all(reading_questions)
+    db.commit()
+
+    listening = models.Test(
+        exam_type="IELTS",
+        level=1,
+        section="Listening",
+        title="Sample Listening",
+    )
+    db.add(listening)
+    db.commit()
+    db.refresh(listening)
+    listening_questions = [
+        models.Question(
+            test_id=listening.id,
+            prompt="What sound comes after 'A' in the alphabet?",
+            options_json="[\"B\", \"C\", \"D\"]",
+            answer_key="B",
+            skill_code="listening",
+            audio_url="sample1.mp3",
+        ),
+        models.Question(
+            test_id=listening.id,
+            prompt="How many days are in a week?",
+            options_json="[\"5\", \"7\", \"9\"]",
+            answer_key="7",
+            skill_code="listening",
+            audio_url="sample2.mp3",
+        ),
+    ]
+    db.add_all(listening_questions)
     db.commit()
 
 
@@ -84,20 +120,20 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
     return user
 
 
-@app.get("/exams/{exam_type}", response_model=schemas.Test)
-def get_exam(exam_type: str, db: Session = Depends(get_db)):
-    test = crud.get_test(db, exam_type)
+@app.get("/exams/{exam_type}/{section}", response_model=schemas.Test)
+def get_exam(exam_type: str, section: str, db: Session = Depends(get_db)):
+    test = crud.get_test(db, exam_type, section)
     if not test:
         raise HTTPException(status_code=404, detail="Test not found")
     return test
 
 
-@app.post("/exams/{exam_type}/submit", response_model=schemas.Attempt)
-def submit_exam(exam_type: str, submission: schemas.ExamSubmission, db: Session = Depends(get_db)):
+@app.post("/exams/{exam_type}/{section}/submit", response_model=schemas.Attempt)
+def submit_exam(exam_type: str, section: str, submission: schemas.ExamSubmission, db: Session = Depends(get_db)):
     user = crud.get_user(db, submission.user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    test = crud.get_test(db, exam_type)
+    test = crud.get_test(db, exam_type, section)
     if not test:
         raise HTTPException(status_code=404, detail="Test not found")
     attempt = crud.record_attempt(db, submission.user_id, test, submission.answers)

--- a/app/models.py
+++ b/app/models.py
@@ -33,6 +33,7 @@ class Question(Base):
     options_json = Column(String)
     answer_key = Column(String)
     skill_code = Column(String)
+    audio_url = Column(String, nullable=True)
     test = relationship("Test", back_populates="questions")
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -18,6 +18,7 @@ class Question(BaseModel):
     options_json: str
     answer_key: str
     skill_code: str
+    audio_url: str | None = None
 
     class Config:
         orm_mode = True

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -25,19 +25,24 @@ function Exams() {
   const [test, setTest] = React.useState(null);
   const [answers, setAnswers] = React.useState({});
   const [score, setScore] = React.useState(null);
+  const [section, setSection] = React.useState('Reading');
 
   React.useEffect(() => {
-    fetch('/exams/IELTS')
+    fetch(`/exams/IELTS/${section}`)
       .then(res => res.json())
-      .then(setTest);
-  }, []);
+      .then(data => {
+        setTest(data);
+        setAnswers({});
+        setScore(null);
+      });
+  }, [section]);
 
   const handleSubmit = () => {
     const payload = {
       user_id: 1,
       answers: Object.entries(answers).map(([question_id, response]) => ({ question_id: parseInt(question_id), response }))
     };
-    fetch('/exams/IELTS/submit', {
+    fetch(`/exams/IELTS/${section}/submit`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
@@ -48,10 +53,22 @@ function Exams() {
 
   return (
     <div>
+      <div>
+        <label>
+          Section:
+          <select value={section} onChange={e => setSection(e.target.value)}>
+            <option value="Reading">Reading</option>
+            <option value="Listening">Listening</option>
+          </select>
+        </label>
+      </div>
       <h2>{test.title}</h2>
       {test.questions.map(q => (
         <div key={q.id}>
           <p>{q.prompt}</p>
+          {q.audio_url && (
+            <audio controls src={q.audio_url}></audio>
+          )}
           {JSON.parse(q.options_json).map(opt => (
             <label key={opt}>
               <input

--- a/tests/test_exam.py
+++ b/tests/test_exam.py
@@ -5,7 +5,7 @@ client = SyncClient(app)
 
 
 def test_get_exam():
-    resp = client.get('/exams/IELTS')
+    resp = client.get('/exams/IELTS/Reading')
     assert resp.status_code == 200
     data = resp.json()
     assert data['exam_type'] == 'IELTS'
@@ -13,12 +13,20 @@ def test_get_exam():
 
 
 def test_submit_exam_and_dashboard_ready():
-    exam = client.get('/exams/IELTS').json()
+    exam = client.get('/exams/IELTS/Reading').json()
     answers = [{'question_id': q['id'], 'response': q['answer_key']} for q in exam['questions']]
     client.post('/users/', json={'name': 'Test', 'target_ielts': 7, 'target_hsk': 180})
     # submit two perfect attempts
     for _ in range(2):
-        resp = client.post('/exams/IELTS/submit', json={'user_id': 1, 'answers': answers})
+        resp = client.post('/exams/IELTS/Reading/submit', json={'user_id': 1, 'answers': answers})
         assert resp.status_code == 200
     dash = client.get('/dashboard/1').json()
     assert dash['exam_ready']['ielts'] is True
+
+
+def test_listening_exam_scoring():
+    exam = client.get('/exams/IELTS/Listening').json()
+    answers = [{'question_id': q['id'], 'response': q['answer_key']} for q in exam['questions']]
+    resp = client.post('/exams/IELTS/Listening/submit', json={'user_id': 1, 'answers': answers})
+    assert resp.status_code == 200
+    assert resp.json()['score'] == 100


### PR DESCRIPTION
## Summary
- seed both reading and listening IELTS tests
- store optional audio URL for questions
- select tests by section in new endpoints
- update CRUD logic for sections and skills
- add simple UI selector for Reading/Listening
- adjust tests for new API and cover listening flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b839f7cc832085f8184e5343dd89