### PR TITLE
Fix runtime React bundling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,11 @@
     <h1>SoloLingua Coach</h1>
     <div id="root"></div>
     <!-- Load the React app (modular structure) -->
-    <script type="text/babel" data-type="module" src="/static/src/index.jsx"></script>
+    <script
+        type="text/babel"
+        data-type="module"
+        data-presets="env,react"
+        src="/static/src/index.jsx"
+    ></script>
 </body>
 </html>

--- a/frontend/out/index.html
+++ b/frontend/out/index.html
@@ -17,6 +17,11 @@
     <h1>SoloLingua Coach</h1>
     <div id="root"></div>
     <!-- Load the React app (modular structure) -->
-    <script type="text/babel" data-type="module" src="/static/src/index.jsx"></script>
+    <script
+        type="text/babel"
+        data-type="module"
+        data-presets="env,react"
+        src="/static/src/index.jsx"
+    ></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix HTML loader by adding Babel presets to allow JSX transform

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857c431e80c8320b6966d9819fbb77e