### PR TITLE
Add practice drills such as vocabulary SRS and quick writing

### DIFF
--- a/app/ai_utils.py
+++ b/app/ai_utils.py
@@ -13,6 +13,13 @@ API_KEY = os.getenv("OPENAI_API_KEY")
 SYSTEM_PROMPT = "You are a certified IELTS Writing examiner. Return JSON with task_response, coherence, lexical, grammar, and overall_band."
 
 
+def grade_speaking(transcript: str) -> Dict:
+    """Return simple fluency feedback based on word count."""
+    words = len(transcript.split())
+    band = min(9, max(5, words // 50 + 5))
+    return {"fluency_band": band}
+
+
 def grade_essay(text: str) -> Dict:
     """Grade the essay with OpenAI or return a simple heuristic result."""
     if openai and API_KEY:

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,5 +1,8 @@
 import json
+from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
+
+from . import ai_utils
 
 from . import models, schemas
 
@@ -56,6 +59,7 @@ def record_attempt(
     attempt.score = correct / total * 100
     db.commit()
     update_skill_profile(db, user_id, test.section.lower(), attempt.score)
+    record_study_session(db, user_id, 15)
     db.refresh(attempt)
     return attempt
 
@@ -122,4 +126,120 @@ def record_essay_attempt(
     db.commit()
     db.refresh(attempt)
     update_skill_profile(db, user_id, "writing", attempt.score)
+    record_study_session(db, user_id, 15)
     return attempt
+
+
+def record_study_session(db: Session, user_id: int, minutes: int) -> models.StudySession:
+    session = models.StudySession(user_id=user_id, minutes=minutes)
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def recent_scores(db: Session, user_id: int, limit: int = 5) -> list[dict]:
+    attempts = (
+        db.query(models.Attempt, models.Test.section)
+        .join(models.Test)
+        .filter(models.Attempt.user_id == user_id)
+        .order_by(models.Attempt.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    essays = (
+        db.query(models.EssayAttempt)
+        .filter(models.EssayAttempt.user_id == user_id)
+        .order_by(models.EssayAttempt.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+    scores = [
+        {
+            "label": sec,
+            "score": att.score,
+            "created_at": att.created_at.isoformat(),
+        }
+        for att, sec in attempts
+    ] + [
+        {
+            "label": "Writing",
+            "score": essay.score,
+            "created_at": essay.created_at.isoformat(),
+        }
+        for essay in essays
+    ]
+    scores.sort(key=lambda x: x["created_at"], reverse=True)
+    return scores[:limit]
+
+
+def study_time_trend(db: Session, user_id: int, days: int = 7) -> list[dict]:
+    cutoff = datetime.utcnow().date().toordinal() - days + 1
+    sessions = (
+        db.query(models.StudySession)
+        .filter(models.StudySession.user_id == user_id)
+        .order_by(models.StudySession.created_at.desc())
+        .all()
+    )
+    totals = {}
+    for s in sessions:
+        day = s.created_at.date().isoformat()
+        if datetime.fromisoformat(day).date().toordinal() < cutoff:
+            continue
+        totals[day] = totals.get(day, 0) + s.minutes
+    trend = [
+        {"date": day, "minutes": totals.get(day, 0)}
+        for day in sorted(totals.keys())
+    ]
+    return trend
+
+
+def recommend_tasks(db: Session, user: models.User, top_n: int = 3) -> list[str]:
+    profile = (
+        db.query(models.SkillProfile)
+        .filter(models.SkillProfile.user_id == user.id)
+        .all()
+    )
+    gaps = sorted(profile, key=lambda p: p.mastery_pct)
+    return [f"Practice {p.skill_code.title()}" for p in gaps[:top_n]]
+
+
+def next_vocab_item(db: Session, user_id: int) -> models.Vocabulary | None:
+    progress = (
+        db.query(models.VocabProgress)
+        .filter(models.VocabProgress.user_id == user_id)
+        .order_by(models.VocabProgress.next_due)
+        .first()
+    )
+    if progress and progress.next_due <= datetime.utcnow():
+        return db.get(models.Vocabulary, progress.vocab_id)
+    vocab = db.query(models.Vocabulary).first()
+    if vocab and not progress:
+        db.add(
+            models.VocabProgress(user_id=user_id, vocab_id=vocab.id)
+        )
+        db.commit()
+        return vocab
+    return progress and db.get(models.Vocabulary, progress.vocab_id)
+
+
+def update_vocab_progress(db: Session, user_id: int, vocab_id: int, correct: bool) -> None:
+    progress = (
+        db.query(models.VocabProgress)
+        .filter_by(user_id=user_id, vocab_id=vocab_id)
+        .first()
+    )
+    if not progress:
+        progress = models.VocabProgress(user_id=user_id, vocab_id=vocab_id)
+        db.add(progress)
+    if correct:
+        progress.interval = min(progress.interval * 2, 30)
+    else:
+        progress.interval = 1
+    progress.next_due = datetime.utcnow() + timedelta(days=progress.interval)
+    db.commit()
+    record_study_session(db, user_id, 1)
+
+
+def grade_speaking(transcript: str) -> dict:
+    return ai_utils.grade_speaking(transcript)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import random
 
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.responses import FileResponse
@@ -27,65 +28,74 @@ app.mount("/static", StaticFiles(directory=FRONTEND_DIR), name="static")
 def seed_content(db: Session) -> None:
     """Create sample IELTS reading and listening tests if none exist."""
     if db.query(models.Test).first():
-        return
+        pass
+    else:
+        reading = models.Test(
+            exam_type="IELTS",
+            level=1,
+            section="Reading",
+            title="Sample Reading",
+        )
+        db.add(reading)
+        db.commit()
+        db.refresh(reading)
+        reading_questions = [
+            models.Question(
+                test_id=reading.id,
+                prompt="What is 2 + 2?",
+                options_json='["3", "4", "5"]',
+                answer_key="4",
+                skill_code="reading",
+            ),
+            models.Question(
+                test_id=reading.id,
+                prompt="Capital of France?",
+                options_json='["London", "Paris", "Berlin"]',
+                answer_key="Paris",
+                skill_code="reading",
+            ),
+        ]
+        db.add_all(reading_questions)
+        db.commit()
 
-    reading = models.Test(
-        exam_type="IELTS",
-        level=1,
-        section="Reading",
-        title="Sample Reading",
-    )
-    db.add(reading)
-    db.commit()
-    db.refresh(reading)
-    reading_questions = [
-        models.Question(
-            test_id=reading.id,
-            prompt="What is 2 + 2?",
-            options_json='["3", "4", "5"]',
-            answer_key="4",
-            skill_code="reading",
-        ),
-        models.Question(
-            test_id=reading.id,
-            prompt="Capital of France?",
-            options_json='["London", "Paris", "Berlin"]',
-            answer_key="Paris",
-            skill_code="reading",
-        ),
-    ]
-    db.add_all(reading_questions)
-    db.commit()
+        listening = models.Test(
+            exam_type="IELTS",
+            level=1,
+            section="Listening",
+            title="Sample Listening",
+        )
+        db.add(listening)
+        db.commit()
+        db.refresh(listening)
+        listening_questions = [
+            models.Question(
+                test_id=listening.id,
+                prompt="What sound comes after 'A' in the alphabet?",
+                options_json='["B", "C", "D"]',
+                answer_key="B",
+                skill_code="listening",
+                audio_url="sample1.mp3",
+            ),
+            models.Question(
+                test_id=listening.id,
+                prompt="How many days are in a week?",
+                options_json='["5", "7", "9"]',
+                answer_key="7",
+                skill_code="listening",
+                audio_url="sample2.mp3",
+            ),
+        ]
+        db.add_all(listening_questions)
+        db.commit()
 
-    listening = models.Test(
-        exam_type="IELTS",
-        level=1,
-        section="Listening",
-        title="Sample Listening",
-    )
-    db.add(listening)
-    db.commit()
-    db.refresh(listening)
-    listening_questions = [
-        models.Question(
-            test_id=listening.id,
-            prompt="What sound comes after 'A' in the alphabet?",
-            options_json='["B", "C", "D"]',
-            answer_key="B",
-            skill_code="listening",
-            audio_url="sample1.mp3",
-        ),
-        models.Question(
-            test_id=listening.id,
-            prompt="How many days are in a week?",
-            options_json='["5", "7", "9"]',
-            answer_key="7",
-            skill_code="listening",
-            audio_url="sample2.mp3",
-        ),
-    ]
-    db.add_all(listening_questions)
-    db.commit()
+    if not db.query(models.Vocabulary).first():
+        vocab = [
+            models.Vocabulary(word="apple", definition="a fruit"),
+            models.Vocabulary(word="book", definition="a reading item"),
+            models.Vocabulary(word="cat", definition="a small animal"),
+        ]
+        db.add_all(vocab)
+        db.commit()
 
 
 with SessionLocal() as db:
@@ -193,4 +203,59 @@ def dashboard(user_id: int, db: Session = Depends(get_db)):
         "skill_profile": [
             {"skill": p.skill_code, "pct": p.mastery_pct} for p in profile
         ],
+        "recommended_tasks": crud.recommend_tasks(db, user),
+        "latest_scores": crud.recent_scores(db, user_id),
+        "study_time": crud.study_time_trend(db, user_id),
     }
+
+
+@app.get("/drills/vocab/{user_id}", response_model=schemas.VocabItem | None)
+def get_vocab_drill(user_id: int, db: Session = Depends(get_db)):
+    return crud.next_vocab_item(db, user_id)
+
+
+@app.post("/drills/vocab/{user_id}/{vocab_id}")
+def review_vocab_drill(
+    user_id: int,
+    vocab_id: int,
+    review: schemas.VocabReview,
+    db: Session = Depends(get_db),
+):
+    crud.update_vocab_progress(db, user_id, vocab_id, review.correct)
+    return {"status": "ok"}
+
+
+WRITING_PROMPTS = [
+    "Describe your favorite hobby.",
+    "What is the best book you've read recently?",
+]
+
+
+@app.get("/drills/quick-write")
+def quick_write_prompt():
+    return {"prompt": random.choice(WRITING_PROMPTS)}
+
+
+@app.post("/drills/quick-write/submit", response_model=schemas.EssayAttempt)
+def quick_write_submit(submission: schemas.EssaySubmission, db: Session = Depends(get_db)):
+    feedback = grade_essay(submission.text)
+    attempt = crud.record_essay_attempt(db, submission.user_id, submission.text, feedback)
+    return {"id": attempt.id, "score": attempt.score, "feedback": feedback}
+
+
+SPEAK_PROMPTS = [
+    "Talk about your hometown.",
+    "Explain a recent challenge you faced.",
+]
+
+
+@app.get("/drills/quick-speak")
+def quick_speak_prompt():
+    return {"prompt": random.choice(SPEAK_PROMPTS)}
+
+
+@app.post("/drills/quick-speak/submit")
+def quick_speak_submit(submission: schemas.SpeakSubmission, db: Session = Depends(get_db)):
+    feedback = crud.grade_speaking(submission.transcript)
+    crud.record_study_session(db, submission.user_id, 1)
+    return {"feedback": feedback}

--- a/app/models.py
+++ b/app/models.py
@@ -79,3 +79,30 @@ class EssayAttempt(Base):
     feedback_json = Column(String)
     score = Column(Float)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class StudySession(Base):
+    __tablename__ = "study_sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    minutes = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Vocabulary(Base):
+    __tablename__ = "vocabulary"
+
+    id = Column(Integer, primary_key=True, index=True)
+    word = Column(String, unique=True, index=True)
+    definition = Column(String)
+
+
+class VocabProgress(Base):
+    __tablename__ = "vocab_progress"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    vocab_id = Column(Integer, ForeignKey("vocabulary.id"))
+    interval = Column(Integer, default=1)
+    next_due = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -77,3 +77,30 @@ class EssayAttempt(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class StudySession(BaseModel):
+    id: int
+    minutes: int
+    created_at: str
+
+    class Config:
+        orm_mode = True
+
+
+class VocabItem(BaseModel):
+    id: int
+    word: str
+    definition: str
+
+    class Config:
+        orm_mode = True
+
+
+class VocabReview(BaseModel):
+    correct: bool
+
+
+class SpeakSubmission(BaseModel):
+    user_id: int
+    transcript: str

--- a/frontend/out/src/App.jsx
+++ b/frontend/out/src/App.jsx
@@ -45,6 +45,10 @@ export default function App() {
     })
   }), /*#__PURE__*/React.createElement(Route, {
     path: "/practice",
-    render: () => /*#__PURE__*/React.createElement(PracticeDrills, null)
+    render: () => user ? /*#__PURE__*/React.createElement(PracticeDrills, {
+      user: user
+    }) : /*#__PURE__*/React.createElement(Redirect, {
+      to: "/setup"
+    })
   })));
 }

--- a/frontend/out/src/components/Dashboard.jsx
+++ b/frontend/out/src/components/Dashboard.jsx
@@ -1,13 +1,46 @@
-export default function Dashboard({
-  user
-}) {
+export default function Dashboard({ user }) {
   const [data, setData] = React.useState(null);
+
   React.useEffect(() => {
     if (!user) return;
-    fetch(`/dashboard/${user.id}`).then(res => res.json()).then(setData);
+    fetch(`/dashboard/${user.id}`)
+      .then(res => res.json())
+      .then(setData);
   }, [user]);
+
   if (!user) return /*#__PURE__*/React.createElement("p", null, "Please create your profile.");
-  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h2", null, "Dashboard"), data ? /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h3", null, "Exam Ready"), /*#__PURE__*/React.createElement("ul", null, /*#__PURE__*/React.createElement("li", null, "IELTS: ", data.exam_ready.ielts ? "Yes" : "No"), /*#__PURE__*/React.createElement("li", null, "HSK: ", data.exam_ready.hsk ? "Yes" : "No")), /*#__PURE__*/React.createElement("h3", null, "Skill Profile"), /*#__PURE__*/React.createElement("table", null, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Skill"), /*#__PURE__*/React.createElement("th", null, "Mastery %"))), /*#__PURE__*/React.createElement("tbody", null, data.skill_profile.map(p => /*#__PURE__*/React.createElement("tr", {
-    key: p.skill
-  }, /*#__PURE__*/React.createElement("td", null, p.skill), /*#__PURE__*/React.createElement("td", null, p.pct.toFixed(1))))))) : /*#__PURE__*/React.createElement("p", null, "Loading..."));
+  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h2", null, "Dashboard"), data ? /*#__PURE__*/React.createElement("div", null,
+    /*#__PURE__*/React.createElement("h3", null, "Exam Ready"),
+    /*#__PURE__*/React.createElement("ul", null,
+      /*#__PURE__*/React.createElement("li", null, "IELTS: ", data.exam_ready.ielts ? "Yes" : "No"),
+      /*#__PURE__*/React.createElement("li", null, "HSK: ", data.exam_ready.hsk ? "Yes" : "No")
+    ),
+    /*#__PURE__*/React.createElement("h3", null, "Skill Profile"),
+    /*#__PURE__*/React.createElement("table", null,
+      /*#__PURE__*/React.createElement("thead", null,
+        /*#__PURE__*/React.createElement("tr", null,
+          /*#__PURE__*/React.createElement("th", null, "Skill"),
+          /*#__PURE__*/React.createElement("th", null, "Mastery %")
+        )
+      ),
+      /*#__PURE__*/React.createElement("tbody", null,
+        data.skill_profile.map(p => /*#__PURE__*/React.createElement("tr", { key: p.skill },
+          /*#__PURE__*/React.createElement("td", null, p.skill),
+          /*#__PURE__*/React.createElement("td", null, p.pct.toFixed(1))
+        ))
+      )
+    ),
+    /*#__PURE__*/React.createElement("h3", null, "Recommended Tasks"),
+    /*#__PURE__*/React.createElement("ul", null,
+      data.recommended_tasks.map((t, i) => /*#__PURE__*/React.createElement("li", { key: i }, t))
+    ),
+    /*#__PURE__*/React.createElement("h3", null, "Recent Scores"),
+    /*#__PURE__*/React.createElement("ul", null,
+      data.latest_scores.map((s, i) => /*#__PURE__*/React.createElement("li", { key: i }, `${s.label}: ${s.score.toFixed(1)}`))
+    ),
+    /*#__PURE__*/React.createElement("h3", null, "Study Time (Last 7 Days)"),
+    /*#__PURE__*/React.createElement("ul", null,
+      data.study_time.map(item => /*#__PURE__*/React.createElement("li", { key: item.date }, `${item.date}: ${item.minutes}m`))
+    )
+  ) : /*#__PURE__*/React.createElement("p", null, "Loading..."));
 }

--- a/frontend/out/src/components/PracticeDrills.jsx
+++ b/frontend/out/src/components/PracticeDrills.jsx
@@ -1,3 +1,64 @@
-export default function PracticeDrills() {
-  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h2", null, "Practice Drills"), /*#__PURE__*/React.createElement("p", null, "Drill activities will be available here."));
+export default function PracticeDrills({
+  user
+}) {
+  const [vocab, setVocab] = React.useState(null);
+  const [quickPrompt, setQuickPrompt] = React.useState(null);
+  const [essay, setEssay] = React.useState('');
+  const [feedback, setFeedback] = React.useState(null);
+  React.useEffect(() => {
+    if (!user) return;
+    fetch(`/drills/vocab/${user.id}`).then(res => res.json()).then(setVocab);
+  }, [user]);
+
+  const handleVocab = correct => {
+    fetch(`/drills/vocab/${user.id}/${vocab.id}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        correct
+      })
+    }).then(() => {
+      fetch(`/drills/vocab/${user.id}`).then(res => res.json()).then(setVocab);
+    });
+  };
+
+  const fetchQuickPrompt = () => {
+    fetch('/drills/quick-write').then(res => res.json()).then(data => {
+      setQuickPrompt(data.prompt);
+      setEssay('');
+      setFeedback(null);
+    });
+  };
+
+  const submitQuick = () => {
+    fetch('/drills/quick-write/submit', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        user_id: user.id,
+        text: essay
+      })
+    }).then(res => res.json()).then(data => setFeedback(data.feedback));
+  };
+
+  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h2", null, "Practice Drills"), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h3", null, "Vocabulary"), vocab ? /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("p", null, vocab.word, " - ", vocab.definition), /*#__PURE__*/React.createElement("button", {
+    onClick: () => handleVocab(true)
+  }, "Know"), /*#__PURE__*/React.createElement("button", {
+    onClick: () => handleVocab(false)
+  }, "Don't Know")) : /*#__PURE__*/React.createElement("button", {
+    onClick: () => fetch(`/drills/vocab/${user.id}`).then(res => res.json()).then(setVocab)
+  }, "Start")), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h3", null, "Quick Write"), quickPrompt ? /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("p", null, quickPrompt), /*#__PURE__*/React.createElement("textarea", {
+    value: essay,
+    onChange: e => setEssay(e.target.value),
+    rows: 5,
+    cols: 40
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: submitQuick
+  }, "Submit"), feedback && /*#__PURE__*/React.createElement("pre", null, JSON.stringify(feedback, null, 2))) : /*#__PURE__*/React.createElement("button", {
+    onClick: fetchQuickPrompt
+  }, "New Prompt")));
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,7 +26,7 @@ export default function App() {
         <Route path="/setup" render={() => <CreateUser onCreated={setUser} />} />
         <Route exact path="/" render={() => user ? <Dashboard user={user} /> : <Redirect to="/setup" />} />
         <Route path="/exams" render={() => user ? <Exams user={user} /> : <Redirect to="/setup" />} />
-        <Route path="/practice" render={() => <PracticeDrills />} />
+        <Route path="/practice" render={() => user ? <PracticeDrills user={user} /> : <Redirect to="/setup" />} />
       </Switch>
     </HashRouter>
   );

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -37,6 +37,24 @@ export default function Dashboard({ user }) {
               ))}
             </tbody>
           </table>
+          <h3>Recommended Tasks</h3>
+          <ul>
+            {data.recommended_tasks.map((t, i) => (
+              <li key={i}>{t}</li>
+            ))}
+          </ul>
+          <h3>Recent Scores</h3>
+          <ul>
+            {data.latest_scores.map((s, i) => (
+              <li key={i}>{s.label}: {s.score.toFixed(1)}</li>
+            ))}
+          </ul>
+          <h3>Study Time (Last 7 Days)</h3>
+          <ul>
+            {data.study_time.map(item => (
+              <li key={item.date}>{item.date}: {item.minutes}m</li>
+            ))}
+          </ul>
         </div>
       ) : (
         <p>Loading...</p>

--- a/frontend/src/components/PracticeDrills.jsx
+++ b/frontend/src/components/PracticeDrills.jsx
@@ -1,8 +1,76 @@
-export default function PracticeDrills() {
+export default function PracticeDrills({ user }) {
+  const [vocab, setVocab] = React.useState(null);
+  const [quickPrompt, setQuickPrompt] = React.useState(null);
+  const [essay, setEssay] = React.useState('');
+  const [feedback, setFeedback] = React.useState(null);
+
+  React.useEffect(() => {
+    if (!user) return;
+    fetch(`/drills/vocab/${user.id}`)
+      .then(res => res.json())
+      .then(setVocab);
+  }, [user]);
+
+  const handleVocab = correct => {
+    fetch(`/drills/vocab/${user.id}/${vocab.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ correct })
+    }).then(() => {
+      fetch(`/drills/vocab/${user.id}`)
+        .then(res => res.json())
+        .then(setVocab);
+    });
+  };
+
+  const fetchQuickPrompt = () => {
+    fetch('/drills/quick-write')
+      .then(res => res.json())
+      .then(data => {
+        setQuickPrompt(data.prompt);
+        setEssay('');
+        setFeedback(null);
+      });
+  };
+
+  const submitQuick = () => {
+    fetch('/drills/quick-write/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: user.id, text: essay })
+    })
+      .then(res => res.json())
+      .then(data => setFeedback(data.feedback));
+  };
+
   return (
     <div>
       <h2>Practice Drills</h2>
-      <p>Drill activities will be available here.</p>
+      <div>
+        <h3>Vocabulary</h3>
+        {vocab ? (
+          <div>
+            <p>{vocab.word} - {vocab.definition}</p>
+            <button onClick={() => handleVocab(true)}>Know</button>
+            <button onClick={() => handleVocab(false)}>Don't Know</button>
+          </div>
+        ) : (
+          <button onClick={() => fetch(`/drills/vocab/${user.id}`).then(res => res.json()).then(setVocab)}>Start</button>
+        )}
+      </div>
+      <div>
+        <h3>Quick Write</h3>
+        {quickPrompt ? (
+          <div>
+            <p>{quickPrompt}</p>
+            <textarea value={essay} onChange={e => setEssay(e.target.value)} rows={5} cols={40} />
+            <button onClick={submitQuick}>Submit</button>
+            {feedback && <pre>{JSON.stringify(feedback, null, 2)}</pre>}
+          </div>
+        ) : (
+          <button onClick={fetchQuickPrompt}>New Prompt</button>
+        )}
+      </div>
     </div>
   );
 }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,16 @@
+from tests.utils import SyncClient
+from app.main import app
+
+client = SyncClient(app)
+
+
+def test_dashboard_extra_fields():
+    user = client.post('/users/', json={'name': 'Dash', 'target_ielts': 6, 'target_hsk': 160}).json()
+    user_id = user['id']
+    exam = client.get('/exams/IELTS/Reading').json()
+    answers = [{'question_id': q['id'], 'response': q['answer_key']} for q in exam['questions']]
+    client.post('/exams/IELTS/Reading/submit', json={'user_id': user_id, 'answers': answers})
+    dash = client.get(f'/dashboard/{user_id}').json()
+    assert 'recommended_tasks' in dash
+    assert 'latest_scores' in dash and len(dash['latest_scores']) >= 1
+    assert 'study_time' in dash

--- a/tests/test_drills.py
+++ b/tests/test_drills.py
@@ -1,0 +1,21 @@
+from tests.utils import SyncClient
+from app.main import app
+
+client = SyncClient(app)
+
+
+def test_vocab_drill_cycle():
+    user_id = client.post('/users/', json={'name': 'Voc', 'target_ielts': 6, 'target_hsk': 160}).json()['id']
+    item = client.get(f'/drills/vocab/{user_id}').json()
+    assert 'word' in item
+    client.post(f'/drills/vocab/{user_id}/{item["id"]}', json={'correct': True})
+    next_item = client.get(f'/drills/vocab/{user_id}').json()
+    assert next_item['id'] == item['id']
+
+
+def test_quick_write():
+    user = client.post('/users/', json={'name': 'Writer2', 'target_ielts': 6, 'target_hsk': 160}).json()
+    prompt = client.get('/drills/quick-write').json()
+    assert 'prompt' in prompt
+    resp = client.post('/drills/quick-write/submit', json={'user_id': user['id'], 'text': 'Hello world'}).json()
+    assert 'score' in resp and 'feedback' in resp


### PR DESCRIPTION
## Summary
- seed sample vocabulary
- implement vocabulary spaced repetition endpoints
- add quick writing and speaking drill endpoints
- expand React practice page with vocab SRS and quick writing
- test drills endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d68d016483208bf8de0d8a37d245