### PR TITLE
Improve adaptive recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ This repository contains a small [FastAPI](https://fastapi.tiangolo.com/) applic
    - `GET /users/{user_id}` – retrieve a user by ID.
    - `GET /exams/IELTS/{section}` – fetch a sample IELTS section (`Reading` or `Listening`).
    - `POST /exams/IELTS/{section}/submit` – submit answers for that section.
-   - `GET /dashboard/{user_id}` – show skill profile and exam-ready status.
+    - `GET /dashboard/{user_id}` – show skill profile and exam-ready status.
+
+The dashboard also surfaces recommended tasks using an adaptive engine.
+Each skill profile entry is compared against your targets (IELTS or HSK).
+The gap `target - mastery_pct` determines priority so the weakest skills
+appear first.
 
 3. **Run tests** *(optional)*
    Ensure dependencies are installed first since the tests use `httpx` for the

--- a/app/crud.py
+++ b/app/crud.py
@@ -195,13 +195,20 @@ def study_time_trend(db: Session, user_id: int, days: int = 7) -> list[dict]:
 
 
 def recommend_tasks(db: Session, user: models.User, top_n: int = 3) -> list[str]:
+    """Return a list of practice suggestions sorted by mastery gap."""
     profile = (
         db.query(models.SkillProfile)
         .filter(models.SkillProfile.user_id == user.id)
         .all()
     )
-    gaps = sorted(profile, key=lambda p: p.mastery_pct)
-    return [f"Practice {p.skill_code.title()}" for p in gaps[:top_n]]
+    english = {"reading", "listening", "writing", "speaking"}
+    skill_gaps: list[tuple[float, str]] = []
+    for p in profile:
+        target = user.target_ielts * 10 if p.skill_code in english else user.target_hsk
+        gap = target - p.mastery_pct
+        skill_gaps.append((gap, p.skill_code))
+    skill_gaps.sort(key=lambda g: g[0], reverse=True)
+    return [f"Practice {code.title()}" for _, code in skill_gaps[:top_n]]
 
 
 def next_vocab_item(db: Session, user_id: int) -> models.Vocabulary | None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,7 @@
 from tests.utils import SyncClient
 from app.main import app
+from app.database import SessionLocal
+from app import crud
 
 client = SyncClient(app)
 
@@ -14,3 +16,19 @@ def test_dashboard_extra_fields():
     assert 'recommended_tasks' in dash
     assert 'latest_scores' in dash and len(dash['latest_scores']) >= 1
     assert 'study_time' in dash
+
+
+def test_recommendation_sorting_by_gap():
+    user = client.post(
+        '/users/',
+        json={'name': 'Gap', 'target_ielts': 7, 'target_hsk': 200},
+    ).json()
+    user_id = user['id']
+    with SessionLocal() as db:
+        crud.update_skill_profile(db, user_id, 'reading', 60)
+        crud.update_skill_profile(db, user_id, 'listening', 65)
+        crud.update_skill_profile(db, user_id, 'hanzi', 150)
+    dash = client.get(f'/dashboard/{user_id}').json()
+    tasks = dash['recommended_tasks']
+    assert tasks[0] == 'Practice Hanzi'
+    assert 'Listening' in tasks[-1]


### PR DESCRIPTION
## Summary
- compute mastery gaps against targets in `recommend_tasks`
- note adaptive engine logic in `README`
- add test to verify recommendations sort by gap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e16e15108320b03292b09c00c1d0