### PR TITLE
Add frontend layout and dashboard improvements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,20 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SoloLingua Coach</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
-        nav a { margin-right: 1rem; text-decoration: none; color: #0366d6; }
-        nav a.active { font-weight: bold; text-decoration: underline; }
-        section { margin-bottom: 2rem; }
-        table { border-collapse: collapse; margin-top: 1rem; }
-        th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
-    </style>
+    <link rel="stylesheet" href="/static/style.css" />
     <script src="/static/react.development.js"></script>
     <script src="/static/react-dom.development.js"></script>
     <script src="/static/react-router-dom.min.js"></script>
 </head>
 <body>
-    <h1>SoloLingua Coach</h1>
     <div id="root"></div>
     <!-- Load the React app (modular structure) -->
     <script type="module" src="/static/src/index.jsx"></script>

--- a/frontend/out/index.html
+++ b/frontend/out/index.html
@@ -4,20 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SoloLingua Coach</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
-        nav a { margin-right: 1rem; text-decoration: none; color: #0366d6; }
-        nav a.active { font-weight: bold; text-decoration: underline; }
-        section { margin-bottom: 2rem; }
-        table { border-collapse: collapse; margin-top: 1rem; }
-        th, td { border: 1px solid #ccc; padding: 0.25rem 0.5rem; }
-    </style>
+    <link rel="stylesheet" href="/static/style.css" />
     <script src="/static/react.development.js"></script>
     <script src="/static/react-dom.development.js"></script>
     <script src="/static/react-router-dom.min.js"></script>
 </head>
 <body>
-    <h1>SoloLingua Coach</h1>
     <div id="root"></div>
     <!-- Load the React app (modular structure) -->
     <script type="module" src="/static/src/index.jsx"></script>

--- a/frontend/out/src/App.jsx
+++ b/frontend/out/src/App.jsx
@@ -2,57 +2,30 @@ import CreateUser from './components/CreateUser.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import Exams from './components/Exams.jsx';
 import PracticeDrills from './components/PracticeDrills.jsx';
-const {
-  HashRouter,
-  Route,
-  Switch,
-  NavLink,
-  Redirect
-} = ReactRouterDOM;
+import Layout from './Layout.jsx';
+
+const { HashRouter, Route, Switch, Redirect } = ReactRouterDOM;
+
 export default function App() {
   const [user, setUser] = React.useState(null);
+
   React.useEffect(() => {
     const stored = localStorage.getItem('sololingua_user');
     if (stored) {
       setUser(JSON.parse(stored));
     }
   }, []);
-  return /*#__PURE__*/React.createElement(HashRouter, null, /*#__PURE__*/React.createElement("nav", null, /*#__PURE__*/React.createElement(NavLink, {
-    exact: true,
-    to: "/",
-    activeClassName: "active"
-  }, "Dashboard"), ' | ', /*#__PURE__*/React.createElement(NavLink, {
-    to: "/exams",
-    activeClassName: "active"
-  }, "Exams"), ' | ', /*#__PURE__*/React.createElement(NavLink, {
-    to: "/practice",
-    activeClassName: "active"
-  }, "Practice")), /*#__PURE__*/React.createElement(Switch, null, /*#__PURE__*/React.createElement(Route, {
-    path: "/setup",
-    render: () => /*#__PURE__*/React.createElement(CreateUser, {
-      onCreated: setUser
-    })
-  }), /*#__PURE__*/React.createElement(Route, {
-    exact: true,
-    path: "/",
-    render: () => user ? /*#__PURE__*/React.createElement(Dashboard, {
-      user: user
-    }) : /*#__PURE__*/React.createElement(Redirect, {
-      to: "/setup"
-    })
-  }), /*#__PURE__*/React.createElement(Route, {
-    path: "/exams",
-    render: () => user ? /*#__PURE__*/React.createElement(Exams, {
-      user: user
-    }) : /*#__PURE__*/React.createElement(Redirect, {
-      to: "/setup"
-    })
-  }), /*#__PURE__*/React.createElement(Route, {
-    path: "/practice",
-    render: () => user ? /*#__PURE__*/React.createElement(PracticeDrills, {
-      user: user
-    }) : /*#__PURE__*/React.createElement(Redirect, {
-      to: "/setup"
-    })
-  })));
+
+  return (
+    <HashRouter>
+      <Layout>
+        <Switch>
+          <Route path="/setup" render={() => <CreateUser onCreated={setUser} />} />
+          <Route exact path="/" render={() => user ? <Dashboard user={user} /> : <Redirect to="/setup" />} />
+          <Route path="/exams" render={() => user ? <Exams user={user} /> : <Redirect to="/setup" />} />
+          <Route path="/practice" render={() => user ? <PracticeDrills user={user} /> : <Redirect to="/setup" />} />
+        </Switch>
+      </Layout>
+    </HashRouter>
+  );
 }

--- a/frontend/out/src/Layout.jsx
+++ b/frontend/out/src/Layout.jsx
@@ -1,0 +1,19 @@
+const { NavLink } = ReactRouterDOM;
+
+export default function Layout({ children }) {
+  return (
+    <div>
+      <header className="header">
+        <h1>SoloLingua Coach</h1>
+      </header>
+      <nav className="nav">
+        <NavLink exact to="/" activeClassName="active">Dashboard</NavLink>
+        <NavLink to="/exams" activeClassName="active">Exams</NavLink>
+        <NavLink to="/practice" activeClassName="active">Practice</NavLink>
+      </nav>
+      <div className="container">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/out/src/components/Dashboard.jsx
+++ b/frontend/out/src/components/Dashboard.jsx
@@ -8,39 +8,67 @@ export default function Dashboard({ user }) {
       .then(setData);
   }, [user]);
 
-  if (!user) return /*#__PURE__*/React.createElement("p", null, "Please create your profile.");
-  return /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("h2", null, "Dashboard"), data ? /*#__PURE__*/React.createElement("div", null,
-    /*#__PURE__*/React.createElement("h3", null, "Exam Ready"),
-    /*#__PURE__*/React.createElement("ul", null,
-      /*#__PURE__*/React.createElement("li", null, "IELTS: ", data.exam_ready.ielts ? "Yes" : "No"),
-      /*#__PURE__*/React.createElement("li", null, "HSK: ", data.exam_ready.hsk ? "Yes" : "No")
-    ),
-    /*#__PURE__*/React.createElement("h3", null, "Skill Profile"),
-    /*#__PURE__*/React.createElement("table", null,
-      /*#__PURE__*/React.createElement("thead", null,
-        /*#__PURE__*/React.createElement("tr", null,
-          /*#__PURE__*/React.createElement("th", null, "Skill"),
-          /*#__PURE__*/React.createElement("th", null, "Mastery %")
-        )
-      ),
-      /*#__PURE__*/React.createElement("tbody", null,
-        data.skill_profile.map(p => /*#__PURE__*/React.createElement("tr", { key: p.skill },
-          /*#__PURE__*/React.createElement("td", null, p.skill),
-          /*#__PURE__*/React.createElement("td", null, p.pct.toFixed(1))
-        ))
-      )
-    ),
-    /*#__PURE__*/React.createElement("h3", null, "Recommended Tasks"),
-    /*#__PURE__*/React.createElement("ul", null,
-      data.recommended_tasks.map((t, i) => /*#__PURE__*/React.createElement("li", { key: i }, t))
-    ),
-    /*#__PURE__*/React.createElement("h3", null, "Recent Scores"),
-    /*#__PURE__*/React.createElement("ul", null,
-      data.latest_scores.map((s, i) => /*#__PURE__*/React.createElement("li", { key: i }, `${s.label}: ${s.score.toFixed(1)}`))
-    ),
-    /*#__PURE__*/React.createElement("h3", null, "Study Time (Last 7 Days)"),
-    /*#__PURE__*/React.createElement("ul", null,
-      data.study_time.map(item => /*#__PURE__*/React.createElement("li", { key: item.date }, `${item.date}: ${item.minutes}m`))
-    )
-  ) : /*#__PURE__*/React.createElement("p", null, "Loading..."));
+  if (!user) return <p>Please create your profile.</p>;
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      {data ? (
+        <div className="card-grid">
+          <div className="card">
+            <h3>Exam Ready</h3>
+            <ul>
+              <li>IELTS: {data.exam_ready.ielts ? 'Yes' : 'No'}</li>
+              <li>HSK: {data.exam_ready.hsk ? 'Yes' : 'No'}</li>
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Skill Profile</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Skill</th>
+                  <th>Mastery %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.skill_profile.map(p => (
+                  <tr key={p.skill}>
+                    <td>{p.skill}</td>
+                    <td>{p.pct.toFixed(1)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="card">
+            <h3>Recommended Tasks</h3>
+            <ul>
+              {data.recommended_tasks.map((t, i) => (
+                <li key={i}>{t}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Recent Scores</h3>
+            <ul>
+              {data.latest_scores.map((s, i) => (
+                <li key={i}>{s.label}: {s.score.toFixed(1)}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Study Time (Last 7 Days)</h3>
+            <ul>
+              {data.study_time.map(item => (
+                <li key={item.date}>{item.date}: {item.minutes}m</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
 }

--- a/frontend/out/src/index.jsx
+++ b/frontend/out/src/index.jsx
@@ -1,2 +1,3 @@
 import App from './App.jsx';
-ReactDOM.render(/*#__PURE__*/React.createElement(App, null), document.getElementById('root'));
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/out/style.css
+++ b/frontend/out/style.css
@@ -1,0 +1,46 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+}
+.header {
+    background: #333;
+    color: #fff;
+    padding: 1rem;
+}
+.nav {
+    background: #f2f2f2;
+    padding: 0.5rem 1rem;
+}
+.nav a {
+    margin-right: 1rem;
+    text-decoration: none;
+    color: #0366d6;
+}
+.nav a.active {
+    font-weight: bold;
+    text-decoration: underline;
+}
+.container {
+    padding: 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+.card-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+.card {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 1rem;
+    flex: 1 1 240px;
+}
+table {
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+th, td {
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,8 +2,9 @@ import CreateUser from './components/CreateUser.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import Exams from './components/Exams.jsx';
 import PracticeDrills from './components/PracticeDrills.jsx';
+import Layout from './Layout.jsx';
 
-const { HashRouter, Route, Switch, NavLink, Redirect } = ReactRouterDOM;
+const { HashRouter, Route, Switch, Redirect } = ReactRouterDOM;
 
 export default function App() {
   const [user, setUser] = React.useState(null);
@@ -17,17 +18,14 @@ export default function App() {
 
   return (
     <HashRouter>
-      <nav>
-        <NavLink exact to="/" activeClassName="active">Dashboard</NavLink>{' | '}
-        <NavLink to="/exams" activeClassName="active">Exams</NavLink>{' | '}
-        <NavLink to="/practice" activeClassName="active">Practice</NavLink>
-      </nav>
-      <Switch>
-        <Route path="/setup" render={() => <CreateUser onCreated={setUser} />} />
-        <Route exact path="/" render={() => user ? <Dashboard user={user} /> : <Redirect to="/setup" />} />
-        <Route path="/exams" render={() => user ? <Exams user={user} /> : <Redirect to="/setup" />} />
-        <Route path="/practice" render={() => user ? <PracticeDrills user={user} /> : <Redirect to="/setup" />} />
-      </Switch>
+      <Layout>
+        <Switch>
+          <Route path="/setup" render={() => <CreateUser onCreated={setUser} />} />
+          <Route exact path="/" render={() => user ? <Dashboard user={user} /> : <Redirect to="/setup" />} />
+          <Route path="/exams" render={() => user ? <Exams user={user} /> : <Redirect to="/setup" />} />
+          <Route path="/practice" render={() => user ? <PracticeDrills user={user} /> : <Redirect to="/setup" />} />
+        </Switch>
+      </Layout>
     </HashRouter>
   );
 }

--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -1,0 +1,19 @@
+const { NavLink } = ReactRouterDOM;
+
+export default function Layout({ children }) {
+  return (
+    <div>
+      <header className="header">
+        <h1>SoloLingua Coach</h1>
+      </header>
+      <nav className="nav">
+        <NavLink exact to="/" activeClassName="active">Dashboard</NavLink>
+        <NavLink to="/exams" activeClassName="active">Exams</NavLink>
+        <NavLink to="/practice" activeClassName="active">Practice</NavLink>
+      </nav>
+      <div className="container">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -14,47 +14,57 @@ export default function Dashboard({ user }) {
     <div>
       <h2>Dashboard</h2>
       {data ? (
-        <div>
-          <h3>Exam Ready</h3>
-          <ul>
-            <li>IELTS: {data.exam_ready.ielts ? 'Yes' : 'No'}</li>
-            <li>HSK: {data.exam_ready.hsk ? 'Yes' : 'No'}</li>
-          </ul>
-          <h3>Skill Profile</h3>
-          <table>
-            <thead>
-              <tr>
-                <th>Skill</th>
-                <th>Mastery %</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.skill_profile.map(p => (
-                <tr key={p.skill}>
-                  <td>{p.skill}</td>
-                  <td>{p.pct.toFixed(1)}</td>
+        <div className="card-grid">
+          <div className="card">
+            <h3>Exam Ready</h3>
+            <ul>
+              <li>IELTS: {data.exam_ready.ielts ? 'Yes' : 'No'}</li>
+              <li>HSK: {data.exam_ready.hsk ? 'Yes' : 'No'}</li>
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Skill Profile</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Skill</th>
+                  <th>Mastery %</th>
                 </tr>
+              </thead>
+              <tbody>
+                {data.skill_profile.map(p => (
+                  <tr key={p.skill}>
+                    <td>{p.skill}</td>
+                    <td>{p.pct.toFixed(1)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="card">
+            <h3>Recommended Tasks</h3>
+            <ul>
+              {data.recommended_tasks.map((t, i) => (
+                <li key={i}>{t}</li>
               ))}
-            </tbody>
-          </table>
-          <h3>Recommended Tasks</h3>
-          <ul>
-            {data.recommended_tasks.map((t, i) => (
-              <li key={i}>{t}</li>
-            ))}
-          </ul>
-          <h3>Recent Scores</h3>
-          <ul>
-            {data.latest_scores.map((s, i) => (
-              <li key={i}>{s.label}: {s.score.toFixed(1)}</li>
-            ))}
-          </ul>
-          <h3>Study Time (Last 7 Days)</h3>
-          <ul>
-            {data.study_time.map(item => (
-              <li key={item.date}>{item.date}: {item.minutes}m</li>
-            ))}
-          </ul>
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Recent Scores</h3>
+            <ul>
+              {data.latest_scores.map((s, i) => (
+                <li key={i}>{s.label}: {s.score.toFixed(1)}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="card">
+            <h3>Study Time (Last 7 Days)</h3>
+            <ul>
+              {data.study_time.map(item => (
+                <li key={item.date}>{item.date}: {item.minutes}m</li>
+              ))}
+            </ul>
+          </div>
         </div>
       ) : (
         <p>Loading...</p>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,46 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+}
+.header {
+    background: #333;
+    color: #fff;
+    padding: 1rem;
+}
+.nav {
+    background: #f2f2f2;
+    padding: 0.5rem 1rem;
+}
+.nav a {
+    margin-right: 1rem;
+    text-decoration: none;
+    color: #0366d6;
+}
+.nav a.active {
+    font-weight: bold;
+    text-decoration: underline;
+}
+.container {
+    padding: 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+.card-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+.card {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 1rem;
+    flex: 1 1 240px;
+}
+table {
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+th, td {
+    border: 1px solid #ccc;
+    padding: 0.25rem 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add a shared `Layout` component for navigation and header
- apply new CSS template for basic layout and card grid
- redesign dashboard using cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f3b51908832089048b4890ff7c7c