### PR TITLE
Implement basic writing exam scoring

### DIFF
--- a/app/ai_utils.py
+++ b/app/ai_utils.py
@@ -1,0 +1,43 @@
+import json
+import os
+from typing import Dict
+
+try:
+    import openai
+except Exception:  # network/installation issues
+    openai = None
+
+MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+API_KEY = os.getenv("OPENAI_API_KEY")
+
+SYSTEM_PROMPT = "You are a certified IELTS Writing examiner. Return JSON with task_response, coherence, lexical, grammar, and overall_band."
+
+
+def grade_essay(text: str) -> Dict:
+    """Grade the essay with OpenAI or return a simple heuristic result."""
+    if openai and API_KEY:
+        try:
+            openai.api_key = API_KEY
+            resp = openai.ChatCompletion.create(
+                model=MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                temperature=0,
+            )
+            content = resp.choices[0].message.content
+            return json.loads(content)
+        except Exception:
+            pass
+    # fallback heuristic
+    words = len(text.split())
+    band = min(9, max(5, words // 50 + 5))
+    feedback = {
+        "task_response": {"band": band, "comment": ""},
+        "coherence": {"band": band, "comment": ""},
+        "lexical": {"band": band, "comment": ""},
+        "grammar": {"band": band, "comment": ""},
+        "overall_band": band,
+    }
+    return feedback

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,3 +1,4 @@
+import json
 from sqlalchemy.orm import Session
 
 from . import models, schemas
@@ -62,18 +63,25 @@ def record_attempt(
 def update_skill_profile(db: Session, user_id: int, skill: str, score: float) -> None:
     profile = (
         db.query(models.SkillProfile)
-        .filter(models.SkillProfile.user_id == user_id, models.SkillProfile.skill_code == skill)
+        .filter(
+            models.SkillProfile.user_id == user_id,
+            models.SkillProfile.skill_code == skill,
+        )
         .first()
     )
     if not profile:
-        profile = models.SkillProfile(user_id=user_id, skill_code=skill, mastery_pct=score)
+        profile = models.SkillProfile(
+            user_id=user_id, skill_code=skill, mastery_pct=score
+        )
         db.add(profile)
     else:
         profile.mastery_pct = (profile.mastery_pct + score) / 2
     db.commit()
 
 
-def latest_attempts(db: Session, user_id: int, exam_type: str, limit: int = 2) -> list[models.Attempt]:
+def latest_attempts(
+    db: Session, user_id: int, exam_type: str, limit: int = 2
+) -> list[models.Attempt]:
     return (
         db.query(models.Attempt)
         .join(models.Test)
@@ -91,7 +99,7 @@ def exam_ready(db: Session, user: models.User, exam_type: str) -> bool:
     scores = [a.score for a in attempts]
     mean = sum(scores) / 2
     variance = sum((s - mean) ** 2 for s in scores) / 2
-    std = variance ** 0.5
+    std = variance**0.5
     if exam_type == "IELTS":
         target = user.target_ielts * 10  # treat as 7.0 -> 70
         threshold = 0.25 * 10
@@ -99,3 +107,19 @@ def exam_ready(db: Session, user: models.User, exam_type: str) -> bool:
         target = user.target_hsk
         threshold = 15
     return min(scores) >= target and std < threshold
+
+
+def record_essay_attempt(
+    db: Session, user_id: int, text: str, feedback: dict
+) -> models.EssayAttempt:
+    attempt = models.EssayAttempt(
+        user_id=user_id,
+        essay_text=text,
+        feedback_json=json.dumps(feedback),
+        score=feedback.get("overall_band", 0) * 10,
+    )
+    db.add(attempt)
+    db.commit()
+    db.refresh(attempt)
+    update_skill_profile(db, user_id, "writing", attempt.score)
+    return attempt

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from .database import engine, SessionLocal
 from . import models, schemas, crud
+from .ai_utils import grade_essay
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = BASE_DIR / "frontend" / "out"
@@ -41,14 +42,14 @@ def seed_content(db: Session) -> None:
         models.Question(
             test_id=reading.id,
             prompt="What is 2 + 2?",
-            options_json="[\"3\", \"4\", \"5\"]",
+            options_json='["3", "4", "5"]',
             answer_key="4",
             skill_code="reading",
         ),
         models.Question(
             test_id=reading.id,
             prompt="Capital of France?",
-            options_json="[\"London\", \"Paris\", \"Berlin\"]",
+            options_json='["London", "Paris", "Berlin"]',
             answer_key="Paris",
             skill_code="reading",
         ),
@@ -69,7 +70,7 @@ def seed_content(db: Session) -> None:
         models.Question(
             test_id=listening.id,
             prompt="What sound comes after 'A' in the alphabet?",
-            options_json="[\"B\", \"C\", \"D\"]",
+            options_json='["B", "C", "D"]',
             answer_key="B",
             skill_code="listening",
             audio_url="sample1.mp3",
@@ -77,7 +78,7 @@ def seed_content(db: Session) -> None:
         models.Question(
             test_id=listening.id,
             prompt="How many days are in a week?",
-            options_json="[\"5\", \"7\", \"9\"]",
+            options_json='["5", "7", "9"]',
             answer_key="7",
             skill_code="listening",
             audio_url="sample2.mp3",
@@ -128,6 +129,26 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
     return user
 
 
+@app.get("/exams/IELTS/Writing")
+def get_writing_prompt():
+    return {
+        "title": "IELTS Writing",
+        "prompt": "Describe a memorable journey you have taken.",
+    }
+
+
+@app.post("/exams/IELTS/Writing/submit", response_model=schemas.EssayAttempt)
+def submit_writing(submission: schemas.EssaySubmission, db: Session = Depends(get_db)):
+    user = crud.get_user(db, submission.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    feedback = grade_essay(submission.text)
+    attempt = crud.record_essay_attempt(
+        db, submission.user_id, submission.text, feedback
+    )
+    return {"id": attempt.id, "score": attempt.score, "feedback": feedback}
+
+
 @app.get("/exams/{exam_type}/{section}", response_model=schemas.Test)
 def get_exam(exam_type: str, section: str, db: Session = Depends(get_db)):
     test = crud.get_test(db, exam_type, section)
@@ -137,7 +158,12 @@ def get_exam(exam_type: str, section: str, db: Session = Depends(get_db)):
 
 
 @app.post("/exams/{exam_type}/{section}/submit", response_model=schemas.Attempt)
-def submit_exam(exam_type: str, section: str, submission: schemas.ExamSubmission, db: Session = Depends(get_db)):
+def submit_exam(
+    exam_type: str,
+    section: str,
+    submission: schemas.ExamSubmission,
+    db: Session = Depends(get_db),
+):
     user = crud.get_user(db, submission.user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -157,8 +183,14 @@ def dashboard(user_id: int, db: Session = Depends(get_db)):
         "ielts": crud.exam_ready(db, user, "IELTS"),
         "hsk": crud.exam_ready(db, user, "HSK"),
     }
-    profile = db.query(models.SkillProfile).filter(models.SkillProfile.user_id == user_id).all()
+    profile = (
+        db.query(models.SkillProfile)
+        .filter(models.SkillProfile.user_id == user_id)
+        .all()
+    )
     return {
         "exam_ready": ready,
-        "skill_profile": [{"skill": p.skill_code, "pct": p.mastery_pct} for p in profile],
+        "skill_profile": [
+            {"skill": p.skill_code, "pct": p.mastery_pct} for p in profile
+        ],
     }

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from .database import Base
 
+
 class User(Base):
     __tablename__ = "users"
 
@@ -67,3 +68,14 @@ class SkillProfile(Base):
     skill_code = Column(String, index=True)
     mastery_pct = Column(Float, default=0.0)
     last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class EssayAttempt(Base):
+    __tablename__ = "essay_attempts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    essay_text = Column(String)
+    feedback_json = Column(String)
+    score = Column(Float)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
 
+
 class UserCreate(BaseModel):
     name: str
     target_ielts: int
     target_hsk: int
+
 
 class User(UserCreate):
     id: int
@@ -53,3 +55,17 @@ class Attempt(BaseModel):
 class ExamSubmission(BaseModel):
     user_id: int
     answers: list[AnswerCreate]
+
+
+class EssaySubmission(BaseModel):
+    user_id: int
+    text: str
+
+
+class EssayAttempt(BaseModel):
+    id: int
+    score: float
+    feedback: dict
+
+    class Config:
+        orm_mode = True

--- a/frontend/out/src/components/Exams.jsx
+++ b/frontend/out/src/components/Exams.jsx
@@ -4,29 +4,51 @@ export default function Exams({
   const [test, setTest] = React.useState(null);
   const [answers, setAnswers] = React.useState({});
   const [score, setScore] = React.useState(null);
+  const [essay, setEssay] = React.useState('');
   const [section, setSection] = React.useState('Reading');
   React.useEffect(() => {
-    fetch(`/exams/IELTS/${section}`).then(res => res.json()).then(data => {
-      setTest(data);
-      setAnswers({});
-      setScore(null);
-    });
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing').then(res => res.json()).then(data => {
+        setTest(data);
+        setEssay('');
+        setScore(null);
+      });
+    } else {
+      fetch(`/exams/IELTS/${section}`).then(res => res.json()).then(data => {
+        setTest(data);
+        setAnswers({});
+        setScore(null);
+      });
+    }
   }, [section]);
   const handleSubmit = () => {
-    const payload = {
-      user_id: user.id,
-      answers: Object.entries(answers).map(([question_id, response]) => ({
-        question_id: parseInt(question_id),
-        response
-      }))
-    };
-    fetch(`/exams/IELTS/${section}/submit`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(payload)
-    }).then(res => res.json()).then(data => setScore(data.score));
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          user_id: user.id,
+          text: essay
+        })
+      }).then(res => res.json()).then(data => setScore(data.score));
+    } else {
+      const payload = {
+        user_id: user.id,
+        answers: Object.entries(answers).map(([question_id, response]) => ({
+          question_id: parseInt(question_id),
+          response
+        }))
+      };
+      fetch(`/exams/IELTS/${section}/submit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(payload)
+      }).then(res => res.json()).then(data => setScore(data.score));
+    }
   };
   if (!user) return /*#__PURE__*/React.createElement("p", null, "Please create your profile first.");
   if (!test) return /*#__PURE__*/React.createElement("p", null, "Loading...");
@@ -37,7 +59,14 @@ export default function Exams({
     value: "Reading"
   }, "Reading"), /*#__PURE__*/React.createElement("option", {
     value: "Listening"
-  }, "Listening")))), /*#__PURE__*/React.createElement("h2", null, test.title), test.questions.map(q => /*#__PURE__*/React.createElement("div", {
+  }, "Listening"), /*#__PURE__*/React.createElement("option", {
+    value: "Writing"
+  }, "Writing")))), /*#__PURE__*/React.createElement("h2", null, test.title), section === 'Writing' ? /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("p", null, test.prompt), /*#__PURE__*/React.createElement("textarea", {
+    value: essay,
+    onChange: e => setEssay(e.target.value),
+    rows: 10,
+    cols: 60
+  })) : test.questions.map(q => /*#__PURE__*/React.createElement("div", {
     key: q.id
   }, /*#__PURE__*/React.createElement("p", null, q.prompt), q.audio_url && /*#__PURE__*/React.createElement("audio", {
     controls: true,

--- a/frontend/src/components/Exams.jsx
+++ b/frontend/src/components/Exams.jsx
@@ -2,28 +2,51 @@ export default function Exams({ user }) {
   const [test, setTest] = React.useState(null);
   const [answers, setAnswers] = React.useState({});
   const [score, setScore] = React.useState(null);
+  const [essay, setEssay] = React.useState('');
   const [section, setSection] = React.useState('Reading');
 
   React.useEffect(() => {
-    fetch(`/exams/IELTS/${section}`)
-      .then(res => res.json())
-      .then(data => {
-        setTest(data);
-        setAnswers({});
-        setScore(null);
-      });
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing')
+        .then(res => res.json())
+        .then(data => {
+          setTest(data);
+          setEssay('');
+          setScore(null);
+        });
+    } else {
+      fetch(`/exams/IELTS/${section}`)
+        .then(res => res.json())
+        .then(data => {
+          setTest(data);
+          setAnswers({});
+          setScore(null);
+        });
+    }
   }, [section]);
 
   const handleSubmit = () => {
-    const payload = {
-      user_id: user.id,
-      answers: Object.entries(answers).map(([question_id, response]) => ({ question_id: parseInt(question_id), response }))
-    };
-    fetch(`/exams/IELTS/${section}/submit`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
-    }).then(res => res.json()).then(data => setScore(data.score));
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: user.id, text: essay })
+      })
+        .then(res => res.json())
+        .then(data => setScore(data.score));
+    } else {
+      const payload = {
+        user_id: user.id,
+        answers: Object.entries(answers).map(([question_id, response]) => ({ question_id: parseInt(question_id), response }))
+      };
+      fetch(`/exams/IELTS/${section}/submit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+        .then(res => res.json())
+        .then(data => setScore(data.score));
+    }
   };
 
   if (!user) return <p>Please create your profile first.</p>;
@@ -37,29 +60,42 @@ export default function Exams({ user }) {
           <select value={section} onChange={e => setSection(e.target.value)}>
             <option value="Reading">Reading</option>
             <option value="Listening">Listening</option>
+            <option value="Writing">Writing</option>
           </select>
         </label>
       </div>
       <h2>{test.title}</h2>
-      {test.questions.map(q => (
-        <div key={q.id}>
-          <p>{q.prompt}</p>
-          {q.audio_url && (
-            <audio controls src={q.audio_url}></audio>
-          )}
-          {JSON.parse(q.options_json).map(opt => (
-            <label key={opt}>
-              <input
-                type="radio"
-                name={q.id}
-                value={opt}
-                onChange={e => setAnswers({ ...answers, [q.id]: e.target.value })}
-              />
-              {opt}
-            </label>
-          ))}
+      {section === 'Writing' ? (
+        <div>
+          <p>{test.prompt}</p>
+          <textarea
+            value={essay}
+            onChange={e => setEssay(e.target.value)}
+            rows={10}
+            cols={60}
+          />
         </div>
-      ))}
+      ) : (
+        test.questions.map(q => (
+          <div key={q.id}>
+            <p>{q.prompt}</p>
+            {q.audio_url && (
+              <audio controls src={q.audio_url}></audio>
+            )}
+            {JSON.parse(q.options_json).map(opt => (
+              <label key={opt}>
+                <input
+                  type="radio"
+                  name={q.id}
+                  value={opt}
+                  onChange={e => setAnswers({ ...answers, [q.id]: e.target.value })}
+                />
+                {opt}
+              </label>
+            ))}
+          </div>
+        ))
+      )}
       <button onClick={handleSubmit}>Submit</button>
       {score !== null && (
         <p><strong>Your score: {score}</strong></p>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlalchemy
 pydantic
 httpx
+openai

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,0 +1,25 @@
+from tests.utils import SyncClient
+from app.main import app
+
+client = SyncClient(app)
+
+
+def test_get_writing_prompt():
+    resp = client.get("/exams/IELTS/Writing")
+    assert resp.status_code == 200
+    assert "prompt" in resp.json()
+
+
+def test_submit_writing_returns_band():
+    user = client.post(
+        "/users/", json={"name": "Writer", "target_ielts": 7, "target_hsk": 180}
+    ).json()
+    essay = "This is a short essay about my trip. " * 20
+    resp = client.post(
+        "/exams/IELTS/Writing/submit", json={"user_id": user["id"], "text": essay}
+    )
+    data = resp.json()
+    assert resp.status_code == 200
+    assert "score" in data
+    assert "feedback" in data
+    assert data["score"] > 0


### PR DESCRIPTION
## Summary
- add OpenAI-based essay grading with offline fallback
- store writing attempts and update skill profile
- expose `/exams/IELTS/Writing` and `/exams/IELTS/Writing/submit`
- support writing tasks in the React exam page
- cover new endpoints with tests
- keep `frontend/src` in sync with compiled output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857cfa7e3708320a0f8065f291eaacf