### PR TITLE
Add exam import helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,55 @@ Copy `.env.example` to `.env` and set the values.
 - `OPENAI_API_KEY` – **required** for GPT grading. Without it the app falls back to simple heuristics.
 - `OPENAI_MODEL` – optional model name passed to the OpenAI API (defaults to `gpt-4o`).
 - `SQLALCHEMY_DATABASE_URL` – optional database URL (defaults to `sqlite:///./sololingua.db`).
+
+### Importing exam and practice content
+
+You can load your own exam questions or vocabulary lists from a JSON file.
+Create a file describing the tests and vocab items:
+
+```json
+{
+  "tests": [
+    {
+      "exam_type": "IELTS",
+      "level": 1,
+      "section": "Reading",
+      "title": "Custom Reading",
+      "questions": [
+        {
+          "prompt": "Which planet is known as the Red Planet?",
+          "options": ["Earth", "Mars", "Venus"],
+          "answer_key": "Mars",
+          "skill_code": "reading"
+        }
+      ]
+    }
+  ],
+  "vocabulary": [
+    {"word": "apple", "definition": "a fruit"}
+  ]
+}
+```
+
+Run the import helper to insert the data into the SQLite database:
+
+```bash
+python scripts/import_content.py path/to/content.json
+```
+
+The script uses SQLAlchemy models and works with the same `SQLALCHEMY_DATABASE_URL` as the API.
+
+### Generating exam questions from a PDF
+
+You can also create a test set from any PDF document. The helper below extracts
+text from the PDF and asks OpenAI to produce multiple-choice questions:
+
+```bash
+python scripts/pdf_to_questions.py source.pdf --output exam.json \
+  --exam-type IELTS --section Reading --title "Auto Generated" --level 1
+```
+
+The output JSON follows the same structure as above so you can pass it directly
+to `import_content.py`. The script requires `OPENAI_API_KEY` to be set. If the
+key is missing or the request fails, it falls back to a simple placeholder
+question.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 httpx
 openai
 python-multipart
+pdfminer.six

--- a/scripts/import_content.py
+++ b/scripts/import_content.py
@@ -1,0 +1,77 @@
+"""Helper for loading exam questions and vocabulary into the database."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app import models
+
+
+def import_from_json(path: Path, db: Session) -> None:
+    """Insert tests and vocabulary from a JSON file."""
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    for t in data.get("tests", []):
+        existing = (
+            db.query(models.Test)
+            .filter_by(
+                exam_type=t["exam_type"],
+                level=t.get("level", 1),
+                section=t["section"],
+                title=t.get("title", ""),
+            )
+            .first()
+        )
+        if existing:
+            test = existing
+        else:
+            test = models.Test(
+                exam_type=t["exam_type"],
+                level=t.get("level", 1),
+                section=t["section"],
+                title=t.get("title", ""),
+            )
+            db.add(test)
+            db.commit()
+            db.refresh(test)
+
+        questions = [
+            models.Question(
+                test_id=test.id,
+                prompt=q["prompt"],
+                options_json=json.dumps(q.get("options", [])),
+                answer_key=q["answer_key"],
+                skill_code=q.get("skill_code", ""),
+                audio_url=q.get("audio_url"),
+            )
+            for q in t.get("questions", [])
+        ]
+        db.add_all(questions)
+        db.commit()
+
+    for v in data.get("vocabulary", []):
+        if db.query(models.Vocabulary).filter_by(word=v["word"]).first():
+            continue
+        db.add(
+            models.Vocabulary(word=v["word"], definition=v.get("definition", ""))
+        )
+    db.commit()
+
+
+def main() -> None:
+    import argparse
+    parser = argparse.ArgumentParser(description="Import exam and practice content")
+    parser.add_argument("file", type=Path, help="Path to JSON content file")
+    args = parser.parse_args()
+
+    with SessionLocal() as db:
+        import_from_json(args.file, db)
+    print("Import complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pdf_to_questions.py
+++ b/scripts/pdf_to_questions.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Generate exam questions from a PDF using OpenAI."""
+
+import json
+import os
+from pathlib import Path
+import argparse
+
+from pdfminer.high_level import extract_text
+
+try:
+    import openai
+except Exception:  # network/installation issues
+    openai = None
+
+MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+API_KEY = os.getenv("OPENAI_API_KEY")
+
+SYSTEM_PROMPT = (
+    "You are an English exam generator. Given some source text, "
+    "return a JSON array of questions. Each question must have 'prompt', "
+    "'options', 'answer_key', and optional 'skill_code'."
+)
+
+
+def questions_from_text(text: str) -> list[dict]:
+    """Create questions using OpenAI or return a single fallback question."""
+    if openai and API_KEY:
+        try:
+            openai.api_key = API_KEY
+            resp = openai.ChatCompletion.create(
+                model=MODEL,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                temperature=0,
+            )
+            return json.loads(resp.choices[0].message.content)
+        except Exception:
+            pass
+    # Fallback heuristic
+    return [
+        {
+            "prompt": "What is the main idea of the passage?",
+            "options": ["Option A", "Option B", "Option C"],
+            "answer_key": "Option A",
+            "skill_code": "reading",
+        }
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create exam JSON from a PDF")
+    parser.add_argument("pdf", type=Path, help="Source PDF file")
+    parser.add_argument("--output", type=Path, help="Where to write the JSON")
+    parser.add_argument("--exam-type", default="Custom")
+    parser.add_argument("--section", default="Reading")
+    parser.add_argument("--title", default="Generated Test")
+    parser.add_argument("--level", type=int, default=1)
+    args = parser.parse_args()
+
+    text = extract_text(args.pdf)
+    questions = questions_from_text(text)
+
+    data = {
+        "tests": [
+            {
+                "exam_type": args.exam_type,
+                "level": args.level,
+                "section": args.section,
+                "title": args.title,
+                "questions": questions,
+            }
+        ]
+    }
+
+    out_path = args.output or args.pdf.with_suffix(".json")
+    out_path.write_text(json.dumps(data, indent=2))
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how to load custom exams and practice lists
- provide a helper script that loads data from JSON into the database
- add script to generate exam questions from a PDF using OpenAI
- support PDF parsing by including pdfminer in requirements
- improve import script for better safety and duplicate checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685813142884832096817f50b81ceec0