### PR TITLE
Add admin import and start button

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import random
+import json
 
 from fastapi import FastAPI, Depends, HTTPException, UploadFile, File
 from fastapi.responses import FileResponse
@@ -10,6 +11,7 @@ from sqlalchemy.orm import Session
 from .database import engine, SessionLocal
 from . import models, schemas, crud
 from .ai_utils import grade_essay
+from scripts.import_content import import_from_data
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = BASE_DIR / "frontend" / "out"
@@ -425,4 +427,12 @@ async def speaking_feedback(user_id: int, file: UploadFile = File(...), db: Sess
     feedback = crud.speaking_feedback(data)
     crud.record_study_session(db, user_id, 1)
     return feedback
+
+
+@app.post("/admin/import")
+async def admin_import(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    """Upload a JSON file with tests and vocab to import into the database."""
+    data = json.loads((await file.read()).decode("utf-8"))
+    import_from_data(data, db)
+    return {"status": "ok"}
 

--- a/frontend/out/src/App.js
+++ b/frontend/out/src/App.js
@@ -1,0 +1,87 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+exports['default'] = App;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _componentsCreateUserJsx = require('./components/CreateUser.jsx');
+
+var _componentsCreateUserJsx2 = _interopRequireDefault(_componentsCreateUserJsx);
+
+var _componentsDashboardJsx = require('./components/Dashboard.jsx');
+
+var _componentsDashboardJsx2 = _interopRequireDefault(_componentsDashboardJsx);
+
+var _componentsExamsJsx = require('./components/Exams.jsx');
+
+var _componentsExamsJsx2 = _interopRequireDefault(_componentsExamsJsx);
+
+var _componentsPracticeDrillsJsx = require('./components/PracticeDrills.jsx');
+
+var _componentsPracticeDrillsJsx2 = _interopRequireDefault(_componentsPracticeDrillsJsx);
+
+var _componentsAdminJsx = require('./components/Admin.jsx');
+
+var _componentsAdminJsx2 = _interopRequireDefault(_componentsAdminJsx);
+
+var _LayoutJsx = require('./Layout.jsx');
+
+var _LayoutJsx2 = _interopRequireDefault(_LayoutJsx);
+
+var _ReactRouterDOM = ReactRouterDOM;
+var HashRouter = _ReactRouterDOM.HashRouter;
+var Route = _ReactRouterDOM.Route;
+var Switch = _ReactRouterDOM.Switch;
+var Redirect = _ReactRouterDOM.Redirect;
+
+function App() {
+  var _React$useState = React.useState(null);
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var user = _React$useState2[0];
+  var setUser = _React$useState2[1];
+
+  React.useEffect(function () {
+    var stored = localStorage.getItem('sololingua_user');
+    if (stored) {
+      setUser(JSON.parse(stored));
+    }
+  }, []);
+
+  return React.createElement(
+    HashRouter,
+    null,
+    React.createElement(
+      _LayoutJsx2['default'],
+      null,
+      React.createElement(
+        Switch,
+        null,
+        React.createElement(Route, { path: '/setup', render: function () {
+            return React.createElement(_componentsCreateUserJsx2['default'], { onCreated: setUser });
+          } }),
+        React.createElement(Route, { exact: true, path: '/', render: function () {
+            return user ? React.createElement(_componentsDashboardJsx2['default'], { user: user }) : React.createElement(_componentsCreateUserJsx2['default'], { onCreated: setUser });
+          } }),
+        React.createElement(Route, { path: '/exams', render: function () {
+            return user ? React.createElement(_componentsExamsJsx2['default'], { user: user }) : React.createElement(Redirect, { to: '/setup' });
+          } }),
+        React.createElement(Route, { path: '/practice', render: function () {
+            return user ? React.createElement(_componentsPracticeDrillsJsx2['default'], { user: user }) : React.createElement(Redirect, { to: '/setup' });
+          } }),
+        React.createElement(Route, { path: '/admin', render: function () {
+            return React.createElement(_componentsAdminJsx2['default'], null);
+          } })
+      )
+    )
+  );
+}
+
+module.exports = exports['default'];

--- a/frontend/out/src/Layout.js
+++ b/frontend/out/src/Layout.js
@@ -1,0 +1,61 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = Layout;
+var _ReactRouterDOM = ReactRouterDOM;
+var NavLink = _ReactRouterDOM.NavLink;
+
+function Layout(_ref) {
+  var children = _ref.children;
+
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(
+      "nav",
+      { className: "navbar navbar-expand-lg navbar-dark bg-primary" },
+      React.createElement(
+        "div",
+        { className: "container-fluid" },
+        React.createElement(
+          NavLink,
+          { className: "navbar-brand", to: "/" },
+          "SoloLingua"
+        ),
+        React.createElement(
+          "div",
+          { className: "navbar-nav" },
+          React.createElement(
+            NavLink,
+            { exact: true, to: "/", className: "nav-link", activeClassName: "active" },
+            "Dashboard"
+          ),
+          React.createElement(
+            NavLink,
+            { to: "/exams", className: "nav-link", activeClassName: "active" },
+            "Exams"
+          ),
+          React.createElement(
+            NavLink,
+            { to: "/practice", className: "nav-link", activeClassName: "active" },
+            "Practice"
+          ),
+          React.createElement(
+            NavLink,
+            { to: "/admin", className: "nav-link", activeClassName: "active" },
+            "Admin"
+          )
+        )
+      )
+    ),
+    React.createElement(
+      "div",
+      { className: "container mt-4" },
+      children
+    )
+  );
+}
+
+module.exports = exports["default"];

--- a/frontend/out/src/components/Admin.js
+++ b/frontend/out/src/components/Admin.js
@@ -1,0 +1,75 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+exports['default'] = Admin;
+
+function Admin() {
+  var _React$useState = React.useState(null);
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var file = _React$useState2[0];
+  var setFile = _React$useState2[1];
+
+  var _React$useState3 = React.useState('');
+
+  var _React$useState32 = _slicedToArray(_React$useState3, 2);
+
+  var status = _React$useState32[0];
+  var setStatus = _React$useState32[1];
+
+  var handleSubmit = function handleSubmit(e) {
+    e.preventDefault();
+    if (!file) return;
+    var form = new FormData();
+    form.append('file', file);
+    fetch('/admin/import', {
+      method: 'POST',
+      body: form
+    }).then(function (res) {
+      return res.ok ? res.json() : Promise.reject();
+    }).then(function () {
+      return setStatus('Import successful');
+    })['catch'](function () {
+      return setStatus('Import failed');
+    });
+  };
+
+  return React.createElement(
+    'div',
+    { className: 'mt-4' },
+    React.createElement(
+      'h2',
+      { className: 'mb-3' },
+      'Admin'
+    ),
+    React.createElement(
+      'form',
+      { onSubmit: handleSubmit },
+      React.createElement(
+        'div',
+        { className: 'mb-3' },
+        React.createElement('input', { type: 'file', accept: 'application/json', onChange: function (e) {
+            return setFile(e.target.files[0]);
+          }, className: 'form-control' })
+      ),
+      React.createElement(
+        'button',
+        { type: 'submit', className: 'btn btn-primary' },
+        'Import Content'
+      )
+    ),
+    status && React.createElement(
+      'p',
+      { className: 'mt-2' },
+      status
+    )
+  );
+}
+
+module.exports = exports['default'];

--- a/frontend/out/src/components/CreateUser.js
+++ b/frontend/out/src/components/CreateUser.js
@@ -1,0 +1,118 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+exports['default'] = CreateUser;
+
+function CreateUser(_ref) {
+  var onCreated = _ref.onCreated;
+
+  var _React$useState = React.useState('');
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var name = _React$useState2[0];
+  var setName = _React$useState2[1];
+
+  var _React$useState3 = React.useState(6);
+
+  var _React$useState32 = _slicedToArray(_React$useState3, 2);
+
+  var ielts = _React$useState32[0];
+  var setIelts = _React$useState32[1];
+
+  var _React$useState4 = React.useState(180);
+
+  var _React$useState42 = _slicedToArray(_React$useState4, 2);
+
+  var hsk = _React$useState42[0];
+  var setHsk = _React$useState42[1];
+
+  var handleSubmit = function handleSubmit(e) {
+    e.preventDefault();
+    fetch('/users/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name, target_ielts: parseInt(ielts), target_hsk: parseInt(hsk) })
+    }).then(function (res) {
+      return res.json();
+    }).then(function (user) {
+      localStorage.setItem('sololingua_user', JSON.stringify(user));
+      onCreated(user);
+    });
+  };
+
+  return React.createElement(
+    'form',
+    { onSubmit: handleSubmit, className: 'mt-4' },
+    React.createElement(
+      'h2',
+      { className: 'mb-3' },
+      'Welcome to SoloLingua Coach'
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-3' },
+      React.createElement(
+        'label',
+        { className: 'form-label' },
+        'Name',
+        React.createElement('input', {
+          className: 'form-control',
+          value: name,
+          onChange: function (e) {
+            return setName(e.target.value);
+          },
+          required: true
+        })
+      )
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-3' },
+      React.createElement(
+        'label',
+        { className: 'form-label' },
+        'Target IELTS',
+        React.createElement('input', {
+          type: 'number',
+          className: 'form-control',
+          value: ielts,
+          onChange: function (e) {
+            return setIelts(e.target.value);
+          },
+          required: true
+        })
+      )
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-3' },
+      React.createElement(
+        'label',
+        { className: 'form-label' },
+        'Target HSK',
+        React.createElement('input', {
+          type: 'number',
+          className: 'form-control',
+          value: hsk,
+          onChange: function (e) {
+            return setHsk(e.target.value);
+          },
+          required: true
+        })
+      )
+    ),
+    React.createElement(
+      'button',
+      { type: 'submit', className: 'btn btn-primary' },
+      'Create Profile'
+    )
+  );
+}
+
+module.exports = exports['default'];

--- a/frontend/out/src/components/Dashboard.js
+++ b/frontend/out/src/components/Dashboard.js
@@ -1,0 +1,234 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; })();
+
+exports["default"] = Dashboard;
+
+function Dashboard(_ref) {
+  var user = _ref.user;
+
+  var _React$useState = React.useState(null);
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var data = _React$useState2[0];
+  var setData = _React$useState2[1];
+
+  React.useEffect(function () {
+    if (!user) return;
+    fetch("/dashboard/" + user.id).then(function (res) {
+      return res.json();
+    }).then(setData);
+  }, [user]);
+
+  if (!user) return React.createElement(
+    "p",
+    null,
+    "Please create your profile."
+  );
+
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(
+      "h2",
+      null,
+      "Dashboard"
+    ),
+    data ? React.createElement(
+      "div",
+      { className: "row g-3" },
+      React.createElement(
+        "div",
+        { className: "col-md-6 col-lg-4" },
+        React.createElement(
+          "div",
+          { className: "card h-100" },
+          React.createElement(
+            "div",
+            { className: "card-body" },
+            React.createElement(
+              "h5",
+              { className: "card-title" },
+              "Exam Ready"
+            ),
+            React.createElement(
+              "ul",
+              { className: "list-unstyled mb-0" },
+              React.createElement(
+                "li",
+                null,
+                "IELTS: ",
+                data.exam_ready.ielts ? 'Yes' : 'No'
+              ),
+              React.createElement(
+                "li",
+                null,
+                "HSK: ",
+                data.exam_ready.hsk ? 'Yes' : 'No'
+              )
+            )
+          )
+        )
+      ),
+      React.createElement(
+        "div",
+        { className: "col-md-6 col-lg-4" },
+        React.createElement(
+          "div",
+          { className: "card h-100" },
+          React.createElement(
+            "div",
+            { className: "card-body" },
+            React.createElement(
+              "h5",
+              { className: "card-title" },
+              "Skill Profile"
+            ),
+            React.createElement(
+              "table",
+              { className: "table table-sm" },
+              React.createElement(
+                "thead",
+                null,
+                React.createElement(
+                  "tr",
+                  null,
+                  React.createElement(
+                    "th",
+                    null,
+                    "Skill"
+                  ),
+                  React.createElement(
+                    "th",
+                    null,
+                    "Mastery %"
+                  )
+                )
+              ),
+              React.createElement(
+                "tbody",
+                null,
+                data.skill_profile.map(function (p) {
+                  return React.createElement(
+                    "tr",
+                    { key: p.skill },
+                    React.createElement(
+                      "td",
+                      null,
+                      p.skill
+                    ),
+                    React.createElement(
+                      "td",
+                      null,
+                      p.pct.toFixed(1)
+                    )
+                  );
+                })
+              )
+            )
+          )
+        )
+      ),
+      React.createElement(
+        "div",
+        { className: "col-md-6 col-lg-4" },
+        React.createElement(
+          "div",
+          { className: "card h-100" },
+          React.createElement(
+            "div",
+            { className: "card-body" },
+            React.createElement(
+              "h5",
+              { className: "card-title" },
+              "Recommended Tasks"
+            ),
+            React.createElement(
+              "ul",
+              { className: "mb-0" },
+              data.recommended_tasks.map(function (t, i) {
+                return React.createElement(
+                  "li",
+                  { key: i },
+                  t
+                );
+              })
+            )
+          )
+        )
+      ),
+      React.createElement(
+        "div",
+        { className: "col-md-6 col-lg-4" },
+        React.createElement(
+          "div",
+          { className: "card h-100" },
+          React.createElement(
+            "div",
+            { className: "card-body" },
+            React.createElement(
+              "h5",
+              { className: "card-title" },
+              "Recent Scores"
+            ),
+            React.createElement(
+              "ul",
+              { className: "mb-0" },
+              data.latest_scores.map(function (s, i) {
+                return React.createElement(
+                  "li",
+                  { key: i },
+                  s.label,
+                  ": ",
+                  s.score.toFixed(1)
+                );
+              })
+            )
+          )
+        )
+      ),
+      React.createElement(
+        "div",
+        { className: "col-md-6 col-lg-4" },
+        React.createElement(
+          "div",
+          { className: "card h-100" },
+          React.createElement(
+            "div",
+            { className: "card-body" },
+            React.createElement(
+              "h5",
+              { className: "card-title" },
+              "Study Time (Last 7 Days)"
+            ),
+            React.createElement(
+              "ul",
+              { className: "mb-0" },
+              data.study_time.map(function (item) {
+                return React.createElement(
+                  "li",
+                  { key: item.date },
+                  item.date,
+                  ": ",
+                  item.minutes,
+                  "m"
+                );
+              })
+            )
+          )
+        )
+      )
+    ) : React.createElement(
+      "p",
+      null,
+      "Loading..."
+    )
+  );
+}
+
+module.exports = exports["default"];

--- a/frontend/out/src/components/Exams.js
+++ b/frontend/out/src/components/Exams.js
@@ -1,0 +1,357 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports['default'] = Exams;
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function Exams(_ref) {
+  var user = _ref.user;
+
+  var _React$useState = React.useState(null);
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var test = _React$useState2[0];
+  var setTest = _React$useState2[1];
+
+  var _React$useState3 = React.useState({});
+
+  var _React$useState32 = _slicedToArray(_React$useState3, 2);
+
+  var answers = _React$useState32[0];
+  var setAnswers = _React$useState32[1];
+
+  var _React$useState4 = React.useState(null);
+
+  var _React$useState42 = _slicedToArray(_React$useState4, 2);
+
+  var score = _React$useState42[0];
+  var setScore = _React$useState42[1];
+
+  var _React$useState5 = React.useState(null);
+
+  var _React$useState52 = _slicedToArray(_React$useState5, 2);
+
+  var result = _React$useState52[0];
+  var setResult = _React$useState52[1];
+
+  var _React$useState6 = React.useState('');
+
+  var _React$useState62 = _slicedToArray(_React$useState6, 2);
+
+  var essay = _React$useState62[0];
+  var setEssay = _React$useState62[1];
+
+  var _React$useState7 = React.useState('Reading');
+
+  var _React$useState72 = _slicedToArray(_React$useState7, 2);
+
+  var section = _React$useState72[0];
+  var setSection = _React$useState72[1];
+
+  var DURATIONS = { Reading: 60, Listening: 60, Writing: 60 };
+
+  var _React$useState8 = React.useState(DURATIONS[section]);
+
+  var _React$useState82 = _slicedToArray(_React$useState8, 2);
+
+  var timeLeft = _React$useState82[0];
+  var setTimeLeft = _React$useState82[1];
+
+  var _React$useState9 = React.useState(false);
+
+  var _React$useState92 = _slicedToArray(_React$useState9, 2);
+
+  var started = _React$useState92[0];
+  var setStarted = _React$useState92[1];
+
+  React.useEffect(function () {
+    if (!started) return;
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing').then(function (res) {
+        return res.json();
+      }).then(function (data) {
+        setTest(data);
+        setEssay('');
+        setScore(null);
+        setResult(null);
+      });
+    } else {
+      fetch('/exams/IELTS/' + section).then(function (res) {
+        return res.json();
+      }).then(function (data) {
+        setTest(data);
+        setAnswers({});
+        setScore(null);
+        setResult(null);
+      });
+    }
+  }, [section, started]);
+
+  React.useEffect(function () {
+    var timer = undefined;
+    if (test && started) {
+      setTimeLeft(DURATIONS[section]);
+      timer = setInterval(function () {
+        setTimeLeft(function (prev) {
+          if (prev <= 1) {
+            clearInterval(timer);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return function () {
+      return clearInterval(timer);
+    };
+  }, [test, section, started]);
+
+  var handleSubmit = function handleSubmit() {
+    if (section === 'Writing') {
+      fetch('/exams/IELTS/Writing/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: user.id, text: essay })
+      }).then(function (res) {
+        return res.json();
+      }).then(function (data) {
+        setScore(data.score);
+        setResult(data);
+      });
+    } else {
+      var payload = {
+        user_id: user.id,
+        answers: Object.entries(answers).map(function (_ref2) {
+          var _ref22 = _slicedToArray(_ref2, 2);
+
+          var question_id = _ref22[0];
+          var response = _ref22[1];
+          return { question_id: parseInt(question_id), response: response };
+        })
+      };
+      fetch('/exams/IELTS/' + section + '/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      }).then(function (res) {
+        return res.json();
+      }).then(function (data) {
+        setScore(data.score);
+        setResult(data);
+      });
+    }
+  };
+
+  if (!user) return React.createElement(
+    'p',
+    null,
+    'Please create your profile first.'
+  );
+  if (!started) {
+    return React.createElement(
+      'div',
+      { className: 'mt-4' },
+      React.createElement(
+        'div',
+        { className: 'mb-3' },
+        React.createElement(
+          'label',
+          { className: 'form-label' },
+          'Section',
+          React.createElement(
+            'select',
+            {
+              className: 'form-select',
+              value: section,
+              onChange: function (e) {
+                setSection(e.target.value);
+                setStarted(false);
+                setTest(null);
+              }
+            },
+            React.createElement(
+              'option',
+              { value: 'Reading' },
+              'Reading'
+            ),
+            React.createElement(
+              'option',
+              { value: 'Listening' },
+              'Listening'
+            ),
+            React.createElement(
+              'option',
+              { value: 'Writing' },
+              'Writing'
+            )
+          )
+        )
+      ),
+      React.createElement(
+        'button',
+        { onClick: function () {
+            return setStarted(true);
+          }, className: 'btn btn-primary' },
+        'Start'
+      )
+    );
+  }
+  if (!test) return React.createElement(
+    'p',
+    null,
+    'Loading...'
+  );
+
+  return React.createElement(
+    'div',
+    { className: 'mt-4' },
+    React.createElement(
+      'div',
+      { className: 'mb-3' },
+      React.createElement(
+        'label',
+        { className: 'form-label' },
+        'Section',
+        React.createElement(
+          'select',
+          {
+            className: 'form-select',
+            value: section,
+            onChange: function (e) {
+              setSection(e.target.value);
+              setStarted(false);
+              setTest(null);
+            }
+          },
+          React.createElement(
+            'option',
+            { value: 'Reading' },
+            'Reading'
+          ),
+          React.createElement(
+            'option',
+            { value: 'Listening' },
+            'Listening'
+          ),
+          React.createElement(
+            'option',
+            { value: 'Writing' },
+            'Writing'
+          )
+        )
+      )
+    ),
+    React.createElement(
+      'h2',
+      { className: 'mb-3' },
+      test.title
+    ),
+    started && React.createElement(
+      'p',
+      null,
+      'Time left: ',
+      timeLeft,
+      's'
+    ),
+    section === 'Writing' ? React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'p',
+        null,
+        test.prompt
+      ),
+      React.createElement('textarea', {
+        value: essay,
+        onChange: function (e) {
+          return setEssay(e.target.value);
+        },
+        rows: 10,
+        cols: 60
+      })
+    ) : test.questions.map(function (q) {
+      return React.createElement(
+        'div',
+        { key: q.id },
+        React.createElement(
+          'p',
+          null,
+          q.prompt
+        ),
+        q.audio_url && React.createElement('audio', { controls: true, src: q.audio_url }),
+        JSON.parse(q.options_json).map(function (opt) {
+          return React.createElement(
+            'div',
+            { className: 'form-check', key: opt },
+            React.createElement('input', {
+              type: 'radio',
+              className: 'form-check-input',
+              name: q.id,
+              value: opt,
+              onChange: function (e) {
+                return setAnswers(_extends({}, answers, _defineProperty({}, q.id, e.target.value)));
+              }
+            }),
+            React.createElement(
+              'label',
+              { className: 'form-check-label' },
+              opt
+            )
+          );
+        })
+      );
+    }),
+    React.createElement(
+      'button',
+      { onClick: handleSubmit, className: 'btn btn-primary mt-3', disabled: !started || timeLeft === 0 },
+      'Submit'
+    ),
+    score !== null && React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'p',
+        null,
+        React.createElement(
+          'strong',
+          null,
+          'Your score: ',
+          score
+        )
+      ),
+      result && section === 'Writing' && React.createElement(
+        'pre',
+        null,
+        JSON.stringify(result.feedback, null, 2)
+      ),
+      result && section !== 'Writing' && React.createElement(
+        'ul',
+        null,
+        result.answers.map(function (a) {
+          return React.createElement(
+            'li',
+            { key: a.question_id },
+            'Q',
+            a.question_id,
+            ': ',
+            a.correct ? '✓' : '✗',
+            ' (you: ',
+            a.response,
+            ')'
+          );
+        })
+      )
+    )
+  );
+}
+
+module.exports = exports['default'];

--- a/frontend/out/src/components/PracticeDrills.js
+++ b/frontend/out/src/components/PracticeDrills.js
@@ -1,0 +1,243 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+exports['default'] = PracticeDrills;
+
+function PracticeDrills(_ref) {
+  var user = _ref.user;
+
+  var _React$useState = React.useState(null);
+
+  var _React$useState2 = _slicedToArray(_React$useState, 2);
+
+  var vocab = _React$useState2[0];
+  var setVocab = _React$useState2[1];
+
+  var _React$useState3 = React.useState(null);
+
+  var _React$useState32 = _slicedToArray(_React$useState3, 2);
+
+  var grammar = _React$useState32[0];
+  var setGrammar = _React$useState32[1];
+
+  var _React$useState4 = React.useState(null);
+
+  var _React$useState42 = _slicedToArray(_React$useState4, 2);
+
+  var grammarResult = _React$useState42[0];
+  var setGrammarResult = _React$useState42[1];
+
+  var _React$useState5 = React.useState(null);
+
+  var _React$useState52 = _slicedToArray(_React$useState5, 2);
+
+  var quickPrompt = _React$useState52[0];
+  var setQuickPrompt = _React$useState52[1];
+
+  var _React$useState6 = React.useState('');
+
+  var _React$useState62 = _slicedToArray(_React$useState6, 2);
+
+  var essay = _React$useState62[0];
+  var setEssay = _React$useState62[1];
+
+  var _React$useState7 = React.useState(null);
+
+  var _React$useState72 = _slicedToArray(_React$useState7, 2);
+
+  var feedback = _React$useState72[0];
+  var setFeedback = _React$useState72[1];
+
+  React.useEffect(function () {
+    if (!user) return;
+    fetch('/drills/vocab/' + user.id).then(function (res) {
+      return res.json();
+    }).then(setVocab);
+    fetch('/drills/grammar/' + user.id).then(function (res) {
+      return res.json();
+    }).then(setGrammar);
+  }, [user]);
+
+  var handleVocab = function handleVocab(correct) {
+    fetch('/drills/vocab/' + user.id + '/' + vocab.id, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ correct: correct })
+    }).then(function () {
+      fetch('/drills/vocab/' + user.id).then(function (res) {
+        return res.json();
+      }).then(setVocab);
+    });
+  };
+
+  var answerGrammar = function answerGrammar(opt) {
+    fetch('/drills/grammar/' + user.id + '/' + grammar.id, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ answer: opt })
+    }).then(function (res) {
+      return res.json();
+    }).then(function (data) {
+      setGrammarResult(data.correct);
+      fetch('/drills/grammar/' + user.id).then(function (res) {
+        return res.json();
+      }).then(setGrammar);
+    });
+  };
+
+  var fetchQuickPrompt = function fetchQuickPrompt() {
+    fetch('/drills/quick-write').then(function (res) {
+      return res.json();
+    }).then(function (data) {
+      setQuickPrompt(data.prompt);
+      setEssay('');
+      setFeedback(null);
+    });
+  };
+
+  var submitQuick = function submitQuick() {
+    fetch('/drills/quick-write/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: user.id, text: essay })
+    }).then(function (res) {
+      return res.json();
+    }).then(function (data) {
+      return setFeedback(data.feedback);
+    });
+  };
+
+  return React.createElement(
+    'div',
+    { className: 'mt-4' },
+    React.createElement(
+      'h2',
+      { className: 'mb-3' },
+      'Practice Drills'
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-4' },
+      React.createElement(
+        'h3',
+        null,
+        'Vocabulary'
+      ),
+      vocab ? React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'p',
+          null,
+          vocab.word,
+          ' - ',
+          vocab.definition
+        ),
+        React.createElement(
+          'button',
+          { onClick: function () {
+              return handleVocab(true);
+            }, className: 'btn btn-success me-2' },
+          'Know'
+        ),
+        React.createElement(
+          'button',
+          { onClick: function () {
+              return handleVocab(false);
+            }, className: 'btn btn-secondary' },
+          'Don\'t Know'
+        )
+      ) : React.createElement(
+        'button',
+        { onClick: function () {
+            return fetch('/drills/vocab/' + user.id).then(function (res) {
+              return res.json();
+            }).then(setVocab);
+          }, className: 'btn btn-primary' },
+        'Start'
+      )
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-4' },
+      React.createElement(
+        'h3',
+        null,
+        'Grammar'
+      ),
+      grammar ? React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'p',
+          null,
+          grammar.prompt
+        ),
+        grammar.options.map(function (opt) {
+          return React.createElement(
+            'button',
+            { key: opt, onClick: function () {
+                return answerGrammar(opt);
+              }, className: 'btn btn-outline-primary me-2 mb-2' },
+            opt
+          );
+        }),
+        grammarResult !== null && React.createElement(
+          'span',
+          { className: 'ms-2' },
+          grammarResult ? 'Correct!' : 'Try again'
+        )
+      ) : React.createElement(
+        'button',
+        { onClick: function () {
+            return fetch('/drills/grammar/' + user.id).then(function (res) {
+              return res.json();
+            }).then(setGrammar);
+          }, className: 'btn btn-primary' },
+        'Start'
+      )
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-4' },
+      React.createElement(
+        'h3',
+        null,
+        'Quick Write'
+      ),
+      quickPrompt ? React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'p',
+          null,
+          quickPrompt
+        ),
+        React.createElement('textarea', { value: essay, onChange: function (e) {
+            return setEssay(e.target.value);
+          }, rows: 5, className: 'form-control mb-2' }),
+        React.createElement(
+          'button',
+          { onClick: submitQuick, className: 'btn btn-primary' },
+          'Submit'
+        ),
+        feedback && React.createElement(
+          'pre',
+          { className: 'mt-2' },
+          JSON.stringify(feedback, null, 2)
+        )
+      ) : React.createElement(
+        'button',
+        { onClick: fetchQuickPrompt, className: 'btn btn-primary' },
+        'New Prompt'
+      )
+    )
+  );
+}
+
+module.exports = exports['default'];

--- a/frontend/out/src/index.js
+++ b/frontend/out/src/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _AppJsx = require('./App.jsx');
+
+var _AppJsx2 = _interopRequireDefault(_AppJsx);
+
+ReactDOM.render(React.createElement(_AppJsx2['default'], null), document.getElementById('root'));

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import CreateUser from './components/CreateUser.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import Exams from './components/Exams.jsx';
 import PracticeDrills from './components/PracticeDrills.jsx';
+import Admin from './components/Admin.jsx';
 import Layout from './Layout.jsx';
 
 const { HashRouter, Route, Switch, Redirect } = ReactRouterDOM;
@@ -24,6 +25,7 @@ export default function App() {
           <Route exact path="/" render={() => user ? <Dashboard user={user} /> : <CreateUser onCreated={setUser} />} />
           <Route path="/exams" render={() => user ? <Exams user={user} /> : <Redirect to="/setup" />} />
           <Route path="/practice" render={() => user ? <PracticeDrills user={user} /> : <Redirect to="/setup" />} />
+          <Route path="/admin" render={() => <Admin />} />
         </Switch>
       </Layout>
     </HashRouter>

--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -9,9 +9,10 @@ export default function Layout({ children }) {
           <div className="navbar-nav">
             <NavLink exact to="/" className="nav-link" activeClassName="active">Dashboard</NavLink>
             <NavLink to="/exams" className="nav-link" activeClassName="active">Exams</NavLink>
-            <NavLink to="/practice" className="nav-link" activeClassName="active">Practice</NavLink>
-          </div>
+          <NavLink to="/practice" className="nav-link" activeClassName="active">Practice</NavLink>
+          <NavLink to="/admin" className="nav-link" activeClassName="active">Admin</NavLink>
         </div>
+      </div>
       </nav>
       <div className="container mt-4">
         {children}

--- a/frontend/src/components/Admin.jsx
+++ b/frontend/src/components/Admin.jsx
@@ -1,0 +1,31 @@
+export default function Admin() {
+  const [file, setFile] = React.useState(null);
+  const [status, setStatus] = React.useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    fetch('/admin/import', {
+      method: 'POST',
+      body: form
+    })
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then(() => setStatus('Import successful'))
+      .catch(() => setStatus('Import failed'));
+  };
+
+  return (
+    <div className="mt-4">
+      <h2 className="mb-3">Admin</h2>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-3">
+          <input type="file" accept="application/json" onChange={e => setFile(e.target.files[0])} className="form-control" />
+        </div>
+        <button type="submit" className="btn btn-primary">Import Content</button>
+      </form>
+      {status && <p className="mt-2">{status}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/Exams.jsx
+++ b/frontend/src/components/Exams.jsx
@@ -7,8 +7,10 @@ export default function Exams({ user }) {
   const [section, setSection] = React.useState('Reading');
   const DURATIONS = { Reading: 60, Listening: 60, Writing: 60 };
   const [timeLeft, setTimeLeft] = React.useState(DURATIONS[section]);
+  const [started, setStarted] = React.useState(false);
 
   React.useEffect(() => {
+    if (!started) return;
     if (section === 'Writing') {
       fetch('/exams/IELTS/Writing')
         .then(res => res.json())
@@ -28,11 +30,11 @@ export default function Exams({ user }) {
           setResult(null);
         });
     }
-  }, [section]);
+  }, [section, started]);
 
   React.useEffect(() => {
     let timer;
-    if (test) {
+    if (test && started) {
       setTimeLeft(DURATIONS[section]);
       timer = setInterval(() => {
         setTimeLeft(prev => {
@@ -45,7 +47,7 @@ export default function Exams({ user }) {
       }, 1000);
     }
     return () => clearInterval(timer);
-  }, [test, section]);
+  }, [test, section, started]);
 
   const handleSubmit = () => {
     if (section === 'Writing') {
@@ -78,6 +80,31 @@ export default function Exams({ user }) {
   };
 
   if (!user) return <p>Please create your profile first.</p>;
+  if (!started) {
+    return (
+      <div className="mt-4">
+        <div className="mb-3">
+          <label className="form-label">
+            Section
+            <select
+              className="form-select"
+              value={section}
+              onChange={e => {
+                setSection(e.target.value);
+                setStarted(false);
+                setTest(null);
+              }}
+            >
+              <option value="Reading">Reading</option>
+              <option value="Listening">Listening</option>
+              <option value="Writing">Writing</option>
+            </select>
+          </label>
+        </div>
+        <button onClick={() => setStarted(true)} className="btn btn-primary">Start</button>
+      </div>
+    );
+  }
   if (!test) return <p>Loading...</p>;
 
   return (
@@ -88,7 +115,11 @@ export default function Exams({ user }) {
           <select
             className="form-select"
             value={section}
-            onChange={e => setSection(e.target.value)}
+            onChange={e => {
+              setSection(e.target.value);
+              setStarted(false);
+              setTest(null);
+            }}
           >
             <option value="Reading">Reading</option>
             <option value="Listening">Listening</option>
@@ -97,7 +128,7 @@ export default function Exams({ user }) {
         </label>
       </div>
       <h2 className="mb-3">{test.title}</h2>
-      <p>Time left: {timeLeft}s</p>
+      {started && <p>Time left: {timeLeft}s</p>}
       {section === 'Writing' ? (
         <div>
           <p>{test.prompt}</p>
@@ -130,7 +161,7 @@ export default function Exams({ user }) {
           </div>
         ))
       )}
-      <button onClick={handleSubmit} className="btn btn-primary mt-3" disabled={timeLeft === 0}>Submit</button>
+      <button onClick={handleSubmit} className="btn btn-primary mt-3" disabled={!started || timeLeft === 0}>Submit</button>
       {score !== null && (
         <div>
           <p><strong>Your score: {score}</strong></p>

--- a/scripts/import_content.py
+++ b/scripts/import_content.py
@@ -10,11 +10,8 @@ from app.database import SessionLocal
 from app import models
 
 
-def import_from_json(path: Path, db: Session) -> None:
-    """Insert tests and vocabulary from a JSON file."""
-    with path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
-
+def _import(data: dict, db: Session) -> None:
+    """Insert tests and vocabulary from a parsed JSON dict."""
     for t in data.get("tests", []):
         existing = (
             db.query(models.Test)
@@ -52,7 +49,6 @@ def import_from_json(path: Path, db: Session) -> None:
         ]
         db.add_all(questions)
         db.commit()
-
     for v in data.get("vocabulary", []):
         if db.query(models.Vocabulary).filter_by(word=v["word"]).first():
             continue
@@ -60,6 +56,18 @@ def import_from_json(path: Path, db: Session) -> None:
             models.Vocabulary(word=v["word"], definition=v.get("definition", ""))
         )
     db.commit()
+
+
+def import_from_json(path: Path, db: Session) -> None:
+    """Insert tests and vocabulary from a JSON file."""
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    _import(data, db)
+
+
+def import_from_data(data: dict, db: Session) -> None:
+    """Insert tests and vocabulary from an in-memory object."""
+    _import(data, db)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- require user to click **Start** before exams begin and disable submit until started
- add Admin page to upload new practice resources
- expose `/admin/import` endpoint for uploading content
- compile frontend assets

## Testing
- `npx -y babel frontend/src --out-dir frontend/out/src --presets @babel/preset-react`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685815acc1408320b999392d9f99f648